### PR TITLE
Improve percentage change vignette

### DIFF
--- a/R/pct_change.R
+++ b/R/pct_change.R
@@ -1,7 +1,7 @@
 #' Compute percentage change 
 #' 
 #' Computes the percentage change over a sequence of values, defined as 100 * (B
-#' - A) / A, where A is the sum of the first half of the values and B is the sum
+#' / A - 1), where A is the sum of the first half of the values and B is the sum
 #' of the second half. This is a convenience function to be used inside of a
 #' call to `epi_slide()`, see the [percentage change
 #' vignette](https://cmu-delphi.github.io/epiprocess/articles/pct_change.html)

--- a/R/slide.R
+++ b/R/slide.R
@@ -45,8 +45,8 @@
 #'   data in between November 1 and 5. Default is 14. 
 #' @param align One of "right", "center", or "left", indicating the alignment of
 #'   the sliding window relative to the reference time point. If the alignment
-#'   is "center" and `n` is even, then one more time point will be used before
-#'   the reference time point than after. Default is "right".
+#'   is "center" and `n` is even, then one more time point will be used after
+#'   the reference time point than before. Default is "right".
 #' @param before Positive integer less than `n`, specifying the number of time
 #'   points to use in the sliding window strictly before the reference time
 #'   point. For example, setting `before = n-1` would be the same as setting
@@ -107,8 +107,8 @@ epi_slide = function(x, f, ..., n = 14, align = c("right", "center", "left"),
       after_num = 0
     }
     else if (align == "center") {
-      before_num = before_fun(ceiling((n-1)/2))
-      after_num = before_fun(floor((n-1)/2))
+      before_num = before_fun(floor((n-1)/2))
+      after_num = before_fun(ceiling((n-1)/2))
     }
     else {
       before_num = 0

--- a/vignettes/pct_change.Rmd
+++ b/vignettes/pct_change.Rmd
@@ -11,7 +11,7 @@ A basic way of assessing growth in a signal is to look at its percentage change
 over two neighboring time windows. We investigate this in the current vignette,
 using the `pct_change()` convenience function from the `epiprocess` package,
 inside of a call to `epi_slide()`. As before, we'll look at state-level daily
-reported COVID-19 cases.
+reported COVID-19 cases, smoothed using a 7-day trailing average. 
 
 ```{r, message = FALSE}
 library(covidcast)
@@ -26,7 +26,8 @@ x <- covidcast_signal(data_source = "jhu-csse",
                       geo_values = "fl")  %>%
   as.epi_df() %>%
   rename(cases = value) %>%
-  select(geo_value, time_value, cases)
+  select(geo_value, time_value, cases) %>% 
+  epi_slide(cases = mean(cases), n = 7)
 ```
 
 ## Percentage change
@@ -35,23 +36,27 @@ The `pct_change()` function is a simple convenience function that takes a single
 argument `var`, the variable whose percentage change is to be computed. If `var`
 has length N, which is assumed to be even, and A and B denote the sum of the
 first N/2 and last N/2 values in `var`, respectively, then `pct_change(var)`
-returns 100 * (B - A) / A. (If the length of `var` is odd, then its first value
+returns 100 * (B / A - 1). (If the length of `var` is odd, then its first value
 is ignored, for the sake of the computation.)
 
 Used in call to `epi_slide()`, we can fluidly compute percentage change values 
 in a variable over time: 
 
 ```{r}
-x <- epi_slide(x, pct_change = pct_change(cases), n = 14, complete = TRUE)
+x <- epi_slide(x, pct_change = pct_change(cases), n = 14, align = "center",
+               complete = TRUE)
 head(x, 21) %>% print(n = Inf)
 ```
 
-Thus to be clear, the `pct_change` value computed on (for example) November 14 
-is the percentage change between the total cases from November 1 to 7, and the
-total from November 8 to November 14. The argument `complete = TRUE` in the call
-to `epi_slide()` specifies that a complete window of `n = 14` time points must
-be available for the computation, which is why values in the `pct_change` column
-are `NA` from November 1 to 13.
+Note the use of `align = "center"`, which centers the running window around the
+reference time point (as opposed to the default, `align = "right"`). Thus to be
+clear, the `pct_change` value computed on (for example) June 7 is the percentage
+change between the sum of cases from June 1 to 7, and the sum from June 8 to
+June 14. This can be seen as an estimate of the weekly *growth rate* on June 7.
+Furthermore, the argument `complete = TRUE` in the call to `epi_slide()`
+specifies that a complete window of `n = 14` time points must be available for
+the computation, which is why the the percentage change values for the first 6 
+time points  (from June 1 to June 6) are `NA`.
 
 Next we plot these values alongside the signal itself. We highlight the periods
 in time for which the percentage change is above 10% (in red) and below -10% (in
@@ -74,42 +79,6 @@ p1 <- ggplot(x, aes(x = time_value, y = cases)) +
   geom_line() + 
   scale_x_date(minor_breaks = "month", date_labels = "%b %y") +
   labs(x = "Date", y = "Reported COVID-19 cases")
-
-p2 <- ggplot(x, aes(x = time_value, y = pct_change)) + 
-  geom_line() + 
-  geom_hline(yintercept = threshold_upper, linetype = 2, col = 2) +
-  geom_hline(yintercept = threshold_lower, linetype = 2, col = 4) +
-  scale_x_date(minor_breaks = "month", date_labels = "%b %y") +
-  labs(x = "Date", y = "Weekly percentage change") 
-
-gridExtra::grid.arrange(p1, p2, nrow = 1)
-```
-
-## Smoothing via 7-day averaging
-
-The percentage change in the last figure appears pretty volatile in some parts, 
-which is not too surprising, looking at how wiggly the signal is itself. With a
-suitable call to `epi_slide()`, we can either pre-smooth or post-smooth using a
-7-day trailing average. The differences here (between these two approaches) do 
-not end up being very noticeable at all (which is not unexpected, due to the way
-in which percentage change is defined; it is already defined using a sum over a 
-7-day period). We just show results for one of these approaches, pre-smoothing.
-
-```{r, message = FALSE, warning = FALSE, fig.width = 9, fig.height = 4}
-x <- x %>%
-  epi_slide(cases_7dav = mean(cases), n = 7) %>%
-  epi_slide(pct_change = pct_change(cases_7dav), n = 14, complete = TRUE)
-
-p1 <- ggplot(x, aes(x = time_value, y = cases_7dav)) + 
-  geom_tile(data = x %>% filter(pct_change >= threshold_upper),
-            aes(x = time_value, y = 0, width = 7, height = Inf), 
-            fill = 2, alpha = 0.1) + 
-  geom_tile(data = x %>% filter(pct_change <= threshold_lower),
-            aes(x = time_value, y = 0, width = 7, height = Inf), 
-            fill = 4, alpha = 0.1) + 
-  geom_line() + 
-  scale_x_date(minor_breaks = "month", date_labels = "%b %y") +
-  labs(x = "Date", y = "Reported COVID-19 cases (7-day average)")
 
 p2 <- ggplot(x, aes(x = time_value, y = pct_change)) + 
   geom_line() + 

--- a/vignettes/slide.Rmd
+++ b/vignettes/slide.Rmd
@@ -18,8 +18,8 @@ By default, the meaning of one time step is inferred from the `time_type` of the
 `epi_df` object under consideration. If `time_type` is "day", then one time step
 is one day. The time step can also be specified manually in the call to
 `epi_slide()`; you can read the cocumentation for more details. Furthermore, the
-alignment of the running window used in `epi_slide()` can either be "trailing"
-or "centered"; the default is "trailing", and is what we use in this and most
+alignment of the running window used in `epi_slide()` can either be "right", 
+"center", or "left"; the default is "right", and is what we use in this and most
 other vignettes, without specifying otherwise.
 
 Similar to the getting started guide, we'll fetch daily reported COVID-19 cases


### PR DESCRIPTION
Fixed some small things in the percentage change vignette:

- changed the sliding window to be centered (more natural here)
- mentioned the connection to growth rates
- just went with 7-day averaged case data from the start