### PR TITLE
km-compactify_rectify2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,6 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Depends: 
     R (>= 2.10)
-

--- a/R/archive.R
+++ b/R/archive.R
@@ -211,8 +211,8 @@ epi_archive =
                           set compactify to TRUE or fix these rows")
               # call elim with for loop, up to 6
               for (i in min(6,nrow(elim))) {
-                print(elim[i,])
                 # TODO: This needs to print rows properly!
+                print(elim[i,])
               }
               if (nrow(elim) > 6) {
                 print("And so on...")

--- a/R/archive.R
+++ b/R/archive.R
@@ -175,12 +175,12 @@ epi_archive =
             
             # Checks for LOCF's in a data frame
             rm_locf <- function(df) {
-             filter(df,if_any(c(everything(),-key_vars),~ !is_locf(.))) 
+             filter(df,if_any(c(everything(),-version),~ !is_locf(.))) 
             }
             
             # Keeps LOCF values, such as to be printed
             keep_locf <- function(df) {
-              filter(df,if_all(c(everything(),-key_vars),~ is_locf(.))) 
+              filter(df,if_all(c(everything(),-version),~ is_locf(.))) 
             }
             
             # Runs compactify on data frame

--- a/R/archive.R
+++ b/R/archive.R
@@ -152,7 +152,12 @@ epi_archive =
             }
             
             # Finish off with compactify
-            if (missing(compacify)) compactify = NULL
+            if (missing(compacify)) {
+              compactify = NULL
+            } else if (compactify != TRUE && compactify != FALSE) {
+              Warn("Non-boolean value inserted for boolean. Resetting to default")
+              compactify = NULL
+            }
 
             # Create the data table; if x was an un-keyed data.table itself,
             # then the call to as.data.table() will fail to set keys, so we
@@ -166,6 +171,7 @@ epi_archive =
             self$geo_type = geo_type
             self$time_type = time_type
             self$additional_metadata = additional_metadata
+            self$compactify = compactify
           },
           print = function() {
             cat("An `epi_archive` object, with metadata:\n")

--- a/R/archive.R
+++ b/R/archive.R
@@ -177,6 +177,9 @@ epi_archive =
                      is.na(vec) & is.na(dplyr::lag(vec)))
             }
             
+            # LOCF is defined by a row where all values except for the version
+            # differ from their respective lag values
+            
             # Checks for LOCF's in a data frame
             rm_locf <- function(df) {
              filter(df,if_any(c(everything(),-version),~ !is_locf(.))) 

--- a/R/archive.R
+++ b/R/archive.R
@@ -198,19 +198,21 @@ epi_archive =
             
             # Warns about redundant rows
             if (is.null(compactify) && nrow(elim) > 0) {
-              warning_intro <- paste("\nLOCF rows found. To remove warning,",
-              "set compactify to TRUE or fix these rows: \n")
+              warning_intro <- paste("LOCF rows found;",
+                                     "these have been removed: \n")
               
               # elim size capped at 6
               len <- nrow(elim)
               elim <- elim[1:min(6,len),]
               
               warning_data <- paste(collapse="\n",capture.output(print(elim)))
-              warning_msg <- paste(warning_intro,warning_data)
+              
+              warning_message <- paste(warning_intro,warning_data)
               if (len > 6) {
-                warning_msg <- paste0(warning_msg,"\nAnd so on...")
+                warning_message <- paste0(warning_msg,"\nAnd so on...")
               }
-              rlang::warn(warning_msg)
+              
+              rlang::warn(warning_message)
             }
             
             # Instantiate all self variables

--- a/R/archive.R
+++ b/R/archive.R
@@ -209,7 +209,10 @@ epi_archive =
               
               warning_message <- paste(warning_intro,warning_data)
               if (len > 6) {
-                warning_message <- paste0(warning_msg,"\nAnd so on...")
+                warning_message <- paste0(warning_message,"\n",
+                                          "Only the first 6 LOCF rows are
+                                          printed. There are more than 6 LOCF
+                                          rows.")
               }
               
               rlang::warn(warning_message)

--- a/R/archive.R
+++ b/R/archive.R
@@ -164,6 +164,12 @@ epi_archive =
               df # stub
             }
             
+            # Warns about redundant rows
+            if (is.null(compactify)) {
+              Warn("Note: redundant rows found. To remove warning,
+                          set compactify to TRUE or fix these rows")
+            }
+            
             # Create the data table; if x was an un-keyed data.table itself,
             # then the call to as.data.table() will fail to set keys, so we
             # need to check this, then do it manually if needed
@@ -203,13 +209,7 @@ epi_archive =
             cat(sprintf("Public methods: %s",
                         paste(names(epi_archive$public_methods),
                               collapse = ", ")))
-            if (is.null(compactify)) {
-              cat("----------\n")
-              cat(sprintf("Note: redundant rows found. To remove warning,
-                          set compactify to TRUE or fix these rows"))
-              # print redundant row numbers
-              # stub
-            }
+
           },
           #####
 #' @description Generates a snapshot in `epi_df` format as of a given version.

--- a/R/archive.R
+++ b/R/archive.R
@@ -169,7 +169,9 @@ epi_archive =
             # functions for LOCF
             # orders data frame to observe potential LOCF
             order_locf <- function(df) {
-              arrange(df,geo_value,time_value,version)
+              ifelse(is.null(other_keys),
+                     arrange(df,geo_value,time_value,version),
+                     arrange(df,geo_value,time_value,other_keys,version))
             }
 
             # Checks for LOCF's in a data frame (this includes NA's)

--- a/R/archive.R
+++ b/R/archive.R
@@ -184,9 +184,9 @@ epi_archive =
               )
             }
             
-            # Checks if a value is LOCF
-            is_locf <- function(row) {
-              FALSE #stub
+            # Checks for LOCF's in a data frame
+            is_locf <- function(df) {
+              df #stub
             }
             
             # Remove LOCF values

--- a/R/archive.R
+++ b/R/archive.R
@@ -212,6 +212,7 @@ epi_archive =
               # call elim with for loop, up to 6
               for (i in min(6,nrow(elim))) {
                 print(elim[i,])
+                # TODO: This needs to print rows properly!
               }
               if (nrow(elim) > 6) {
                 print("And so on...")

--- a/R/archive.R
+++ b/R/archive.R
@@ -172,7 +172,7 @@ epi_archive =
             
             # Checks to see if a value in a vector is LOCF
             is_locf <- function(vec) {
-              if_else(!is.na(vec) & !is.na(dplyr::lag(vec)),
+              dplyr::if_else(!is.na(vec) & !is.na(dplyr::lag(vec)),
                      vec == lag(vec),
                      is.na(vec) & is.na(dplyr::lag(vec)))
             }

--- a/R/archive.R
+++ b/R/archive.R
@@ -110,7 +110,7 @@ epi_archive =
 #' @return An `epi_archive` object.
 #' @importFrom data.table as.data.table key setkeyv
           initialize = function(x, geo_type, time_type, other_keys,
-                                additional_metadata, compacify) {
+                                additional_metadata, compactify) {
             # Check that we have a data frame
             if (!is.data.frame(x)) {
               Abort("`x` must be a data frame.")

--- a/R/archive.R
+++ b/R/archive.R
@@ -210,10 +210,14 @@ epi_archive =
               warning_message <- paste(warning_intro,warning_data)
               if (len > 6) {
                 warning_message <- paste0(warning_message,"\n",
-                                          "Only the first 6 LOCF rows are
-                                          printed. There are more than 6 LOCF
-                                          rows.")
+                                          "Only the first 6 LOCF rows are ",
+                                          "printed. There are more than 6 LOCF",
+                                          " rows.")
               }
+              
+              warning_message <- paste0(warning_message,"\n",
+                                        "To disable warning but still remove ",
+                                        "LOCF rows, set compactify=FALSE.")
               
               rlang::warn(warning_message)
             }

--- a/R/archive.R
+++ b/R/archive.R
@@ -206,17 +206,18 @@ epi_archive =
             }
             
             # Warns about redundant rows
-            if (is.null(compactify) & nrow(elim) > 0) {
-              Warn("Note: redundant rows found. To remove warning,
-                          set compactify to TRUE or fix these rows")
+            if (is.null(compactify) && nrow(elim) > 0) {
+              warning <- "Redundant rows found. To remove warning,
+                          set compactify to TRUE or fix these rows \n"
               # call elim with for loop, up to 6
-              for (i in min(6,nrow(elim))) {
-                # TODO: This needs to print rows properly!
-                print(elim[i,])
+              for (i in 1:min(6,nrow(elim))) {
+                warning <- paste(warning,
+                  elim[[i,1]],elim[[i,2]],elim[[i,3]],elim[[i,4]],"\n")
               }
               if (nrow(elim) > 6) {
-                print("And so on...")
+                warning <- paste(warning,"And so on...")
               }
+              Warn(warning)
             }
             
             # Instantiate all self variables
@@ -249,7 +250,7 @@ epi_archive =
             cat("----------\n")
             cat(sprintf("Public methods: %s",
                         paste(names(epi_archive$public_methods),
-                              collapse = ", ")))
+                              collapse = ", ")),"\n")
 
           },
           #####

--- a/R/archive.R
+++ b/R/archive.R
@@ -212,7 +212,10 @@ epi_archive =
             if (is.null(compactify)) {
               Warn("Note: redundant rows found. To remove warning,
                           set compactify to TRUE or fix these rows")
-              # call elim with for loop
+              # call elim with for loop, up to 6
+              for (i in min(6,nrow(elim))) {
+                print(elim[i,])
+              }
             }
             
             # Instantiate all self variables
@@ -530,8 +533,9 @@ epi_archive =
 #'                           time_type = "day", 
 #'                           other_keys = "county")
 as_epi_archive = function(x, geo_type, time_type, other_keys,
-                          additional_metadata = list()) {
-  epi_archive$new(x, geo_type, time_type, other_keys, additional_metadata)
+                          additional_metadata = list(),compactify = NULL) {
+  epi_archive$new(x, geo_type, time_type, other_keys, additional_metadata,
+                  compactify)
 }
 
 #' Test for `epi_archive` format

--- a/R/archive.R
+++ b/R/archive.R
@@ -169,7 +169,7 @@ epi_archive =
             # functions for LOCF
             # orders data frame to observe potential LOCF
             order_locf <- function(df) {
-              arrange(df,geo_value,version,time_value)
+              arrange(df,geo_value,time_value,version)
             }
             
             # Check if previous entry is in group.
@@ -177,7 +177,7 @@ epi_archive =
               mutate(df, in_group =
                        tidyr::replace_na(
                          (geo_value == lag(geo_value) &
-                            version == lag(version)),
+                            time_value == lag(time_value)),
                          FALSE
                        )
               )

--- a/R/archive.R
+++ b/R/archive.R
@@ -159,14 +159,9 @@ epi_archive =
               compactify = NULL
             }
             
-            # Code for running compactify
-            comp <- function(df) {
-              df #stub
-            }
-            
             # Runs compactify on data frame
             if (compactify == TRUE || is.null(compactify)) {
-              self$comp(df)
+              df # stub
             }
             
             # Create the data table; if x was an un-keyed data.table itself,
@@ -176,7 +171,6 @@ epi_archive =
             DT = as.data.table(x, key = key_vars)
             if (!identical(key_vars, key(DT))) setkeyv(DT, cols = key_vars)
             
-
             # Instantiate all self variables
             self$DT = DT
             self$geo_type = geo_type
@@ -211,8 +205,10 @@ epi_archive =
                               collapse = ", ")))
             if (is.null(compactify)) {
               cat("----------\n")
-              cat(sprintf("To avoid warning, please do the following:"))
-              # !!!
+              cat(sprintf("Note: redundant rows found. To remove warning,
+                          set compactify to TRUE or fix these rows"))
+              # print redundant row numbers
+              # stub
             }
           },
           #####

--- a/R/archive.R
+++ b/R/archive.R
@@ -212,6 +212,7 @@ epi_archive =
             if (is.null(compactify)) {
               cat("----------\n")
               cat(sprintf("To avoid warning, please do the following:"))
+              # !!!
             }
           },
           #####

--- a/R/archive.R
+++ b/R/archive.R
@@ -103,10 +103,10 @@ epi_archive =
 #'   `epi_archive` object. The metadata will have `geo_type` and `time_type`
 #'   fields; named entries from the passed list or will be included as well.
 #' @param compactify Determines whether redundant rows are removed for last
-#'   observation carried first (LOCF) results. Set to TRUE to remove these,
-#'   FALSE to leave as is. Not specifying the argument does the same as TRUE,
-#'   except it also notifies the user of change in the data, as well as the
-#'   methods that can be done to silence the message.
+#'   observation carried first (LOCF) results, as to potentially save space.
+#'   Set to TRUE to remove these, FALSE to leave as is. Not specifying the
+#'   argument does the same as TRUE, except it also notifies the user of change
+#'   in the data by mentioning which rows are LOCF.
 #' @return An `epi_archive` object.
 #' @importFrom data.table as.data.table key setkeyv
           initialize = function(x, geo_type, time_type, other_keys,
@@ -194,7 +194,7 @@ epi_archive =
             
             # Warns about redundant rows
             if (is.null(compactify) && nrow(elim) > 0) {
-              warn <- paste("\nRedundant rows found. To remove warning, set",
+              warn <- paste("\nLOCF rows found. To remove warning, set",
               "compactify to TRUE or fix these rows: \n")
               # call elim with for loop, up to 6
               for (i in 1:min(6,nrow(elim))) {

--- a/R/archive.R
+++ b/R/archive.R
@@ -172,8 +172,9 @@ epi_archive =
               arrange(df,geo_value,time_value,version)
             }
             
-            # Check if previous entry is in group.
-            mutate_in_group <- function(df) {
+            # Check if previous entry is an LCOF value, and adds this column of
+            # Boolean values for the sake of filtering; NA values are FALSE
+            mutate_is_locf <- function(df) {
               mutate(df, in_group =
                        tidyr::replace_na(
                          (geo_value == lag(geo_value) &
@@ -183,11 +184,16 @@ epi_archive =
               )
             }
             
+            # Checks if a value is LOCF
+            is_locf <- function(row) {
+              FALSE #stub
+            }
+            
             # Remove LOCF values
             rm_locf <- function (df) {
               df %>%
                 order_locf() %>%
-                mutate_in_group() %>%
+                mutate_is_locf() %>%
                 filter(!in_group | percent_cli != lag(percent_cli)) %>%
                 select(-in_group)
             }
@@ -196,7 +202,7 @@ epi_archive =
             keep_locf <- function(df) {
               df %>%
                 order_locf() %>%
-                mutate_in_group() %>%
+                mutate_is_locf() %>%
                 filter(in_group & percent_cli == lag(percent_cli)) %>%
                 select(-in_group)  
             }

--- a/R/archive.R
+++ b/R/archive.R
@@ -200,6 +200,9 @@ epi_archive =
             if (is.null(compactify) || compactify == TRUE) {
               elim = keep_locf(DT)
               DT = rm_locf(DT)
+            } else {
+              # Create empty data frame for nrow(elim) to be 0
+              elim = tibble()
             }
             
             # Warns about redundant rows

--- a/R/archive.R
+++ b/R/archive.R
@@ -155,16 +155,27 @@ epi_archive =
             if (missing(compacify)) {
               compactify = NULL
             } else if (compactify != TRUE && compactify != FALSE) {
-              Warn("Non-boolean value inserted for boolean. Resetting to default")
+              Warn("Non-boolean value inserted for compactify. Resetting to default")
               compactify = NULL
             }
-
+            
+            # Code for running compactify
+            comp <- function(df) {
+              df #stub
+            }
+            
+            # Runs compactify on data frame
+            if (compactify == TRUE || is.null(compactify)) {
+              self$comp(df)
+            }
+            
             # Create the data table; if x was an un-keyed data.table itself,
             # then the call to as.data.table() will fail to set keys, so we
             # need to check this, then do it manually if needed
             key_vars = c("geo_value", "time_value", other_keys, "version")
             DT = as.data.table(x, key = key_vars)
             if (!identical(key_vars, key(DT))) setkeyv(DT, cols = key_vars)
+            
 
             # Instantiate all self variables
             self$DT = DT
@@ -198,6 +209,10 @@ epi_archive =
             cat(sprintf("Public methods: %s",
                         paste(names(epi_archive$public_methods),
                               collapse = ", ")))
+            if (is.null(compactify)) {
+              cat("----------\n")
+              cat(sprintf("To avoid warning, please do the following:"))
+            }
           },
           #####
 #' @description Generates a snapshot in `epi_df` format as of a given version.

--- a/R/archive.R
+++ b/R/archive.R
@@ -207,17 +207,18 @@ epi_archive =
             
             # Warns about redundant rows
             if (is.null(compactify) && nrow(elim) > 0) {
-              warning <- "Redundant rows found. To remove warning,
-                          set compactify to TRUE or fix these rows \n"
+              warn <- paste("\nRedundant rows found. To remove warning, set",
+              "compactify to TRUE or fix these rows: \n")
               # call elim with for loop, up to 6
               for (i in 1:min(6,nrow(elim))) {
-                warning <- paste(warning,
-                  elim[[i,1]],elim[[i,2]],elim[[i,3]],elim[[i,4]],"\n")
+                warn <- paste0(warn,
+                  paste(elim[[i,1]],elim[[i,2]],elim[[i,3]],elim[[i,4]],"\n")
+                )
               }
               if (nrow(elim) > 6) {
-                warning <- paste(warning,"And so on...")
+                warn <- paste0(warn,"And so on...")
               }
-              Warn(warning)
+              warning(warn)
             }
             
             # Instantiate all self variables

--- a/R/archive.R
+++ b/R/archive.R
@@ -102,10 +102,15 @@ epi_archive =
 #' @param additional_metadata List of additional metadata to attach to the
 #'   `epi_archive` object. The metadata will have `geo_type` and `time_type`
 #'   fields; named entries from the passed list or will be included as well.
+#' @param compactify Determines whether redundant rows are removed for last
+#'   observation carried first (LOCF) results. Set to TRUE to remove these,
+#'   FALSE to leave as is. Not specifying the argument does the same as TRUE,
+#'   except it also notifies the user of change in the data, as well as the
+#'   methods that can be done to silence the message.
 #' @return An `epi_archive` object.
 #' @importFrom data.table as.data.table key setkeyv
           initialize = function(x, geo_type, time_type, other_keys,
-                                additional_metadata) {
+                                additional_metadata, compacify) {
             # Check that we have a data frame
             if (!is.data.frame(x)) {
               Abort("`x` must be a data frame.")
@@ -132,7 +137,7 @@ epi_archive =
               time_type = guess_time_type(x$time_value)
             }
 
-            # Finish off with small checks on keys variables and metadata
+            # Conduct checks on keys variables and metadata
             if (missing(other_keys)) other_keys = NULL
             if (missing(additional_metadata)) additional_metadata = list()
             if (!all(other_keys %in% names(x))) {
@@ -145,6 +150,9 @@ epi_archive =
                     c("geo_type", "time_type"))) {
               Warn("`additional_metadata` names overlap with existing metadata fields \"geo_type\", \"time_type\".")
             }
+            
+            # Finish off with compactify
+            if (missing(compacify)) compactify = NULL
 
             # Create the data table; if x was an un-keyed data.table itself,
             # then the call to as.data.table() will fail to set keys, so we

--- a/R/archive.R
+++ b/R/archive.R
@@ -104,9 +104,13 @@ epi_archive =
 #'   fields; named entries from the passed list or will be included as well.
 #' @param compactify Determines whether redundant rows are removed for last
 #'   observation carried first (LOCF) results, as to potentially save space.
-#'   Set to TRUE to remove these, FALSE to leave as is. Not specifying the
-#'   argument does the same as TRUE, except it also notifies the user of change
-#'   in the data by mentioning which rows are LOCF.
+#'   Optional, Boolean: As these methods use the last (version of an)
+#'   observation carried forward (LOCF) to interpolate between the version data
+#'   provided, rows that won't change these LOCF results can potentially be
+#'   omitted to save space. Generally, this can be set to TRUE, but if you
+#'   directly inspect or edit the fields of the epi_archive such as the $DT,
+#'   you will have to determine whether compactify=TRUE will still produce
+#'   equivalent results.
 #' @return An `epi_archive` object.
 #' @importFrom data.table as.data.table key setkeyv
           initialize = function(x, geo_type, time_type, other_keys,
@@ -168,9 +172,9 @@ epi_archive =
             
             # Checks to see if a value in a vector is LOCF
             is_locf <- function(vec) {
-              ifelse(!is.na(vec) & !is.na(lag(vec)),
+              ifelse(!is.na(vec) & !is.na(dplyr::lag(vec)),
                      vec == lag(vec),
-                     is.na(vec) & is.na(lag(vec)))
+                     is.na(vec) & is.na(dplyr::lag(vec)))
             }
             
             # Checks for LOCF's in a data frame
@@ -491,6 +495,9 @@ epi_archive =
 #' @param additional_metadata List of additional metadata to attach to the
 #'   `epi_archive` object. The metadata will have `geo_type` and `time_type`
 #'   fields; named entries from the passed list or will be included as well.
+#' @param compactify By default, removes LOCF rows and warns the user about
+#'   them. Optionally, one can input a Boolean: TRUE eliminates LOCF rows,
+#'   while FALSE keeps them.
 #' @return An `epi_archive` object.
 #'
 #' @details This simply a wrapper around the `new()` method of the `epi_archive`

--- a/R/archive.R
+++ b/R/archive.R
@@ -152,12 +152,7 @@ epi_archive =
             }
             
             # Finish off with compactify
-            if (missing(compacify)) {
-              compactify = NULL
-            } else if (compactify != TRUE && compactify != FALSE) {
-              Warn("Non-boolean value inserted for compactify. Resetting to default")
-              compactify = NULL
-            }
+            if (missing(compactify)) compactify = NULL
             
             # Create the data table; if x was an un-keyed data.table itself,
             # then the call to as.data.table() will fail to set keys, so we
@@ -169,7 +164,7 @@ epi_archive =
             # functions for LOCF
             ###
             order <- function(df) {
-              arrange(df,version,time_value,geo_value)
+              arrange(df,geo_value,version,time_value)
             }
             
             # Check if previous entry is in group.
@@ -203,18 +198,21 @@ epi_archive =
             ###
             
             # Runs compactify on data frame
-            if (compactify == TRUE | is.null(compactify)) {
+            if (is.null(compactify) || compactify == TRUE) {
               elim = keep_locf(DT)
               DT = rm_locf(DT)
             }
             
             # Warns about redundant rows
-            if (is.null(compactify)) {
+            if (is.null(compactify) & nrow(elim) > 0) {
               Warn("Note: redundant rows found. To remove warning,
                           set compactify to TRUE or fix these rows")
               # call elim with for loop, up to 6
               for (i in min(6,nrow(elim))) {
                 print(elim[i,])
+              }
+              if (nrow(elim) > 6) {
+                print("And so on...")
               }
             }
             
@@ -223,7 +221,6 @@ epi_archive =
             self$geo_type = geo_type
             self$time_type = time_type
             self$additional_metadata = additional_metadata
-            self$compactify = compactify
           },
           print = function() {
             cat("An `epi_archive` object, with metadata:\n")

--- a/R/archive.R
+++ b/R/archive.R
@@ -162,7 +162,7 @@ epi_archive =
             if (!identical(key_vars, key(DT))) setkeyv(DT, cols = key_vars)
             
             # functions for LOCF
-            ###
+            # orders data frame to observe potential LOCF
             order <- function(df) {
               arrange(df,geo_value,version,time_value)
             }
@@ -195,7 +195,6 @@ epi_archive =
                 filter(in_group & percent_cli == lag(percent_cli)) %>%
                 select(-in_group)  
             }
-            ###
             
             # Runs compactify on data frame
             if (is.null(compactify) || compactify == TRUE) {

--- a/data-raw/archive_cases_dv.R
+++ b/data-raw/archive_cases_dv.R
@@ -14,7 +14,7 @@ archive_cases_dv <- covidcast(
 ) %>% 
   fetch_tbl() %>%
   select(geo_value, time_value, version = issue, percent_cli = value) %>%
-  as_epi_archive()
+  as_epi_archive(compactify=TRUE)
 
 case_rate <- covidcast(
   data_source = "jhu-csse",
@@ -27,7 +27,7 @@ case_rate <- covidcast(
 ) %>%
   fetch_tbl() %>%
   select(geo_value, time_value, version = issue, case_rate = value) %>%
-  as_epi_archive()
+  as_epi_archive(compactify=TRUE)
 
 epix_merge(archive_cases_dv, case_rate, all = TRUE)
 

--- a/man/as_epi_archive.Rd
+++ b/man/as_epi_archive.Rd
@@ -32,6 +32,10 @@ apart from "geo_value", "time_value", and "version".}
 \item{additional_metadata}{List of additional metadata to attach to the
 \code{epi_archive} object. The metadata will have \code{geo_type} and \code{time_type}
 fields; named entries from the passed list or will be included as well.}
+
+\item{compactify}{By default, removes LOCF rows and warns the user about
+them. Optionally, one can input a Boolean: TRUE eliminates LOCF rows,
+while FALSE keeps them.}
 }
 \value{
 An \code{epi_archive} object.

--- a/man/as_epi_archive.Rd
+++ b/man/as_epi_archive.Rd
@@ -43,11 +43,15 @@ examples.
 }
 \details{
 This simply a wrapper around the \code{new()} method of the \code{epi_archive}
-class, so for example:\preformatted{x <- as_epi_archive(df, geo_type = "state", time_type = "day")
-}
+class, so for example:
 
-would be equivalent to:\preformatted{x <- epi_archive$new(df, geo_type = "state", time_type = "day")
-}
+\if{html}{\out{<div class="sourceCode">}}\preformatted{x <- as_epi_archive(df, geo_type = "state", time_type = "day")
+}\if{html}{\out{</div>}}
+
+would be equivalent to:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{x <- epi_archive$new(df, geo_type = "state", time_type = "day")
+}\if{html}{\out{</div>}}
 }
 \examples{
 df <- data.frame (geo_value  = c(replicate(2, "ca"), replicate(2, "fl")),

--- a/man/as_epi_archive.Rd
+++ b/man/as_epi_archive.Rd
@@ -9,7 +9,8 @@ as_epi_archive(
   geo_type,
   time_type,
   other_keys,
-  additional_metadata = list()
+  additional_metadata = list(),
+  compactify = NULL
 )
 }
 \arguments{

--- a/man/epi_archive.Rd
+++ b/man/epi_archive.Rd
@@ -130,14 +130,14 @@ apart from "geo_value", "time_value", and "version".}
 \code{epi_archive} object. The metadata will have \code{geo_type} and \code{time_type}
 fields; named entries from the passed list or will be included as well.}
 
-\item{\code{compactify}}{Determines whether redundant rows are removed for last
-observation carried first (LOCF) results, as to potentially save space.
-Optional, Boolean: As these methods use the last (version of an)
+\item{\code{compactify}}{Optional, Boolean: should we remove rows that are
+considered redundant for the purposes of \code{epi_archive}'s built-in methods
+such as \verb{$as_of}? As these methods use the last (version of an)
 observation carried forward (LOCF) to interpolate between the version data
 provided, rows that won't change these LOCF results can potentially be
-omitted to save space. Generally, this can be set to TRUE, but if you
-directly inspect or edit the fields of the epi_archive such as the $DT,
-you will have to determine whether compactify=TRUE will still produce
+omitted to save space. Generally, this can be set to \code{TRUE}, but if you
+directly inspect or edit the fields of the \code{epi_archive} such as the \verb{$DT},
+you will have to determine whether \code{compactify=TRUE} will still produce
 equivalent results.}
 }
 \if{html}{\out{</div>}}

--- a/man/epi_archive.Rd
+++ b/man/epi_archive.Rd
@@ -104,7 +104,7 @@ Creates a new \code{epi_archive} object.
   time_type,
   other_keys,
   additional_metadata,
-  compacify = NULL
+  compactify
 )}\if{html}{\out{</div>}}
 }
 

--- a/man/epi_archive.Rd
+++ b/man/epi_archive.Rd
@@ -84,17 +84,17 @@ are documented in the wrapper function \code{epix_slide()}.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{epi_archive$new()}}
-\item \href{#method-print}{\code{epi_archive$print()}}
-\item \href{#method-as_of}{\code{epi_archive$as_of()}}
-\item \href{#method-merge}{\code{epi_archive$merge()}}
-\item \href{#method-slide}{\code{epi_archive$slide()}}
-\item \href{#method-clone}{\code{epi_archive$clone()}}
+\item \href{#method-epi_archive-new}{\code{epi_archive$new()}}
+\item \href{#method-epi_archive-print}{\code{epi_archive$print()}}
+\item \href{#method-epi_archive-as_of}{\code{epi_archive$as_of()}}
+\item \href{#method-epi_archive-merge}{\code{epi_archive$merge()}}
+\item \href{#method-epi_archive-slide}{\code{epi_archive$slide()}}
+\item \href{#method-epi_archive-clone}{\code{epi_archive$clone()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-epi_archive-new"></a>}}
+\if{latex}{\out{\hypertarget{method-epi_archive-new}{}}}
 \subsection{Method \code{new()}}{
 Creates a new \code{epi_archive} object.
 \subsection{Usage}{
@@ -143,8 +143,8 @@ An \code{epi_archive} object.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-print"></a>}}
-\if{latex}{\out{\hypertarget{method-print}{}}}
+\if{html}{\out{<a id="method-epi_archive-print"></a>}}
+\if{latex}{\out{\hypertarget{method-epi_archive-print}{}}}
 \subsection{Method \code{print()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{epi_archive$print()}\if{html}{\out{</div>}}
@@ -152,8 +152,8 @@ An \code{epi_archive} object.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-as_of"></a>}}
-\if{latex}{\out{\hypertarget{method-as_of}{}}}
+\if{html}{\out{<a id="method-epi_archive-as_of"></a>}}
+\if{latex}{\out{\hypertarget{method-epi_archive-as_of}{}}}
 \subsection{Method \code{as_of()}}{
 Generates a snapshot in \code{epi_df} format as of a given version.
 See the documentation for the wrapper function \code{epix_as_of()} for details.
@@ -163,8 +163,8 @@ See the documentation for the wrapper function \code{epix_as_of()} for details.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-merge"></a>}}
-\if{latex}{\out{\hypertarget{method-merge}{}}}
+\if{html}{\out{<a id="method-epi_archive-merge"></a>}}
+\if{latex}{\out{\hypertarget{method-epi_archive-merge}{}}}
 \subsection{Method \code{merge()}}{
 Merges another \code{data.table} with the current one, and allows for
 a post-filling of \code{NA} values by last observation carried forward (LOCF).
@@ -175,8 +175,8 @@ See the documentation for the wrapper function \code{epix_merge()} for details.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-slide"></a>}}
-\if{latex}{\out{\hypertarget{method-slide}{}}}
+\if{html}{\out{<a id="method-epi_archive-slide"></a>}}
+\if{latex}{\out{\hypertarget{method-epi_archive-slide}{}}}
 \subsection{Method \code{slide()}}{
 Slides a given function over variables in an \code{epi_archive}
 object. See the documentation for the wrapper function \code{epix_as_of()} for
@@ -198,8 +198,8 @@ details.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-epi_archive-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-epi_archive-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/epi_archive.Rd
+++ b/man/epi_archive.Rd
@@ -104,7 +104,7 @@ Creates a new \code{epi_archive} object.
   time_type,
   other_keys,
   additional_metadata,
-  compacify
+  compacify = NULL
 )}\if{html}{\out{</div>}}
 }
 

--- a/man/epi_archive.Rd
+++ b/man/epi_archive.Rd
@@ -132,9 +132,13 @@ fields; named entries from the passed list or will be included as well.}
 
 \item{\code{compactify}}{Determines whether redundant rows are removed for last
 observation carried first (LOCF) results, as to potentially save space.
-Set to TRUE to remove these, FALSE to leave as is. Not specifying the
-argument does the same as TRUE, except it also notifies the user of change
-in the data by mentioning which rows are LOCF.}
+Optional, Boolean: As these methods use the last (version of an)
+observation carried forward (LOCF) to interpolate between the version data
+provided, rows that won't change these LOCF results can potentially be
+omitted to save space. Generally, this can be set to TRUE, but if you
+directly inspect or edit the fields of the epi_archive such as the $DT,
+you will have to determine whether compactify=TRUE will still produce
+equivalent results.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/epi_archive.Rd
+++ b/man/epi_archive.Rd
@@ -98,7 +98,14 @@ are documented in the wrapper function \code{epix_slide()}.
 \subsection{Method \code{new()}}{
 Creates a new \code{epi_archive} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{epi_archive$new(x, geo_type, time_type, other_keys, additional_metadata)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{epi_archive$new(
+  x,
+  geo_type,
+  time_type,
+  other_keys,
+  additional_metadata,
+  compacify
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -122,6 +129,12 @@ apart from "geo_value", "time_value", and "version".}
 \item{\code{additional_metadata}}{List of additional metadata to attach to the
 \code{epi_archive} object. The metadata will have \code{geo_type} and \code{time_type}
 fields; named entries from the passed list or will be included as well.}
+
+\item{\code{compactify}}{Determines whether redundant rows are removed for last
+observation carried first (LOCF) results. Set to TRUE to remove these,
+FALSE to leave as is. Not specifying the argument does the same as TRUE,
+except it also notifies the user of change in the data, as well as the
+methods that can be done to silence the message.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/epi_archive.Rd
+++ b/man/epi_archive.Rd
@@ -131,10 +131,10 @@ apart from "geo_value", "time_value", and "version".}
 fields; named entries from the passed list or will be included as well.}
 
 \item{\code{compactify}}{Determines whether redundant rows are removed for last
-observation carried first (LOCF) results. Set to TRUE to remove these,
-FALSE to leave as is. Not specifying the argument does the same as TRUE,
-except it also notifies the user of change in the data, as well as the
-methods that can be done to silence the message.}
+observation carried first (LOCF) results, as to potentially save space.
+Set to TRUE to remove these, FALSE to leave as is. Not specifying the
+argument does the same as TRUE, except it also notifies the user of change
+in the data by mentioning which rows are LOCF.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/epi_slide.Rd
+++ b/man/epi_slide.Rd
@@ -104,12 +104,16 @@ incomplete windows) is therefore left up to the user, either through the
 specified function or formula \code{f}, or through post-processing.
 
 If \code{f} is missing, then an expression for tidy evaluation can be specified,
-for example, as in:\preformatted{epi_slide(x, cases_7dav = mean(cases), n = 7)
-}
+for example, as in:
 
-which would be equivalent to:\preformatted{epi_slide(x, function(x, ...) mean(x$cases), n = 7,
+\if{html}{\out{<div class="sourceCode">}}\preformatted{epi_slide(x, cases_7dav = mean(cases), n = 7)
+}\if{html}{\out{</div>}}
+
+which would be equivalent to:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{epi_slide(x, function(x, ...) mean(x$cases), n = 7,
           new_col_name = "cases_7dav")
-}
+}\if{html}{\out{</div>}}
 
 Thus, to be clear, when the computation is specified via an expression for
 tidy evaluation (first example, above), then the name for the new column is

--- a/man/epix_as_of.Rd
+++ b/man/epix_as_of.Rd
@@ -29,11 +29,15 @@ examples.
 }
 \details{
 This is simply a wrapper around the \code{as_of()} method of the
-\code{epi_archive} class, so if \code{x} is an \code{epi_archive} object, then:\preformatted{epix_as_of(x, max_version = v)
-}
+\code{epi_archive} class, so if \code{x} is an \code{epi_archive} object, then:
 
-is equivalent to:\preformatted{x$as_of(max_version = v)
-}
+\if{html}{\out{<div class="sourceCode">}}\preformatted{epix_as_of(x, max_version = v)
+}\if{html}{\out{</div>}}
+
+is equivalent to:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{x$as_of(max_version = v)
+}\if{html}{\out{</div>}}
 }
 \examples{
 epix_as_of(x = archive_cases_dv, 

--- a/man/epix_merge.Rd
+++ b/man/epix_merge.Rd
@@ -35,11 +35,15 @@ examples.
 }
 \details{
 This is simply a wrapper around the \code{merge()} method of the
-\code{epi_archive} class, so if \code{x} and \code{y} are an \code{epi_archive} objects, then:\preformatted{epix_merge(x, y)
-}
+\code{epi_archive} class, so if \code{x} and \code{y} are an \code{epi_archive} objects, then:
 
-is equivalent to:\preformatted{x$merge(y)
-}
+\if{html}{\out{<div class="sourceCode">}}\preformatted{epix_merge(x, y)
+}\if{html}{\out{</div>}}
+
+is equivalent to:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{x$merge(y)
+}\if{html}{\out{</div>}}
 }
 \examples{
 # create two example epi_archive datasets

--- a/man/epix_slide.Rd
+++ b/man/epix_slide.Rd
@@ -115,11 +115,15 @@ should never be used in place of \code{epi_slide()}, and only used when
 version-aware sliding is necessary (as it its purpose).
 
 Finally, this is simply a wrapper around the \code{slide()} method of the
-\code{epi_archive} class, so if \code{x} is an \code{epi_archive} object, then:\preformatted{epix_slide(x, new_var = comp(old_var), n = 120)
-}
+\code{epi_archive} class, so if \code{x} is an \code{epi_archive} object, then:
 
-is equivalent to:\preformatted{x$slide(x, new_var = comp(old_var), n = 120)
-}
+\if{html}{\out{<div class="sourceCode">}}\preformatted{epix_slide(x, new_var = comp(old_var), n = 120)
+}\if{html}{\out{</div>}}
+
+is equivalent to:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{x$slide(x, new_var = comp(old_var), n = 120)
+}\if{html}{\out{</div>}}
 }
 \examples{
 # every date is a reference time point for the 3 day average sliding window

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -21,10 +21,10 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{dplyr}{\code{\link[dplyr]{arrange}}, \code{\link[dplyr]{filter}}, \code{\link[dplyr]{group_by}}, \code{\link[dplyr]{group_modify}}, \code{\link[dplyr]{mutate}}, \code{\link[dplyr]{relocate}}, \code{\link[dplyr]{rename}}, \code{\link[dplyr]{slice}}, \code{\link[dplyr]{ungroup}}}
+  \item{dplyr}{\code{\link[dplyr]{arrange}}, \code{\link[dplyr]{filter}}, \code{\link[dplyr]{group_by}}, \code{\link[dplyr:group_map]{group_modify}}, \code{\link[dplyr]{mutate}}, \code{\link[dplyr]{relocate}}, \code{\link[dplyr]{rename}}, \code{\link[dplyr]{slice}}, \code{\link[dplyr:group_by]{ungroup}}}
 
-  \item{tidyr}{\code{\link[tidyr]{unnest}}}
+  \item{tidyr}{\code{\link[tidyr:nest]{unnest}}}
 
-  \item{tsibble}{\code{\link[tsibble]{as_tsibble}}}
+  \item{tsibble}{\code{\link[tsibble:as-tsibble]{as_tsibble}}}
 }}
 

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -21,10 +21,10 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{dplyr}{\code{\link[dplyr]{arrange}}, \code{\link[dplyr]{filter}}, \code{\link[dplyr]{group_by}}, \code{\link[dplyr:group_map]{group_modify}}, \code{\link[dplyr]{mutate}}, \code{\link[dplyr]{relocate}}, \code{\link[dplyr]{rename}}, \code{\link[dplyr]{slice}}, \code{\link[dplyr:group_by]{ungroup}}}
+  \item{dplyr}{\code{\link[dplyr]{arrange}}, \code{\link[dplyr]{filter}}, \code{\link[dplyr]{group_by}}, \code{\link[dplyr]{group_modify}}, \code{\link[dplyr]{mutate}}, \code{\link[dplyr]{relocate}}, \code{\link[dplyr]{rename}}, \code{\link[dplyr]{slice}}, \code{\link[dplyr]{ungroup}}}
 
-  \item{tidyr}{\code{\link[tidyr:nest]{unnest}}}
+  \item{tidyr}{\code{\link[tidyr]{unnest}}}
 
-  \item{tsibble}{\code{\link[tsibble:as-tsibble]{as_tsibble}}}
+  \item{tsibble}{\code{\link[tsibble]{as_tsibble}}}
 }}
 

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -1,35 +1,24 @@
-library(delphi.epidata)
 library(epiprocess)
 library(data.table)
 library(dplyr)
 
-dv <- covidcast(
-  data_source = "doctor-visits",
-  signals = "smoothed_adj_cli",
-  time_type = "day",
-  geo_type = "state",
-  time_values = epirange(20211101, 20211201),
-  geo_values = "ca",
-  issues = epirange(20211129, 20211129)
-) %>%
-  fetch_tbl() %>%
-  select(geo_value, time_value, version = issue, percent_cli = value)
+dt <- filter(dv$DT,geo_value=="ca")
+dt <- select(dt,-case_rate)
 
-dv_duplicated <- dv
-for (i in 1:8) {
-  dv_duplicated[i,4] <- 6
-}
+test_that("Input for compactify must be NULL or a boolean", {
+  expect_error(as_epi_archive(dv_duplicated,compactify="no"))
+})
   
-dv_true <- as_tibble(as_epi_archive(dv_duplicated,compactify=TRUE)$DT)
-dv_false <- as_tibble(as_epi_archive(dv_duplicated,compactify=FALSE)$DT)
-dv_null <- as_tibble(as_epi_archive(dv_duplicated,compactify=NULL)$DT)
+dv_true <- as_tibble(as_epi_archive(dt,compactify=TRUE)$DT)
+dv_false <- as_tibble(as_epi_archive(dt,compactify=FALSE)$DT)
+dv_null <- as_tibble(as_epi_archive(dt,compactify=NULL)$DT)
 
 test_that("Warning for LOCF with compactify as NULL", {
-  expect_warning(as_epi_archive(dv_duplicated,compactify=NULL))
+  expect_warning(as_epi_archive(dt,compactify=NULL))
 })
 
 test_that("LOCF values are ignored", {
-  expect_identical(nrow(dv_duplicated),nrow(dv_false))
+  expect_identical(nrow(dt),nrow(dv_false))
 })
 
 test_that("LOCF values are taken out", {

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -1,3 +1,39 @@
-test_that("compactify gets an error", {
-  expect_equal(1,1)
+library(delphi.epidata)
+library(epiprocess)
+library(data.table)
+library(dplyr)
+
+dv <- covidcast(
+  data_source = "doctor-visits",
+  signals = "smoothed_adj_cli",
+  time_type = "day",
+  geo_type = "state",
+  time_values = epirange(20211101, 20211201),
+  geo_values = "ca",
+  issues = epirange(20211129, 20211129)
+) %>%
+  fetch_tbl() %>%
+  select(geo_value, time_value, version = issue, percent_cli = value)
+
+dv_duplicated <- dv
+for (i in 1:5) {
+  dv_duplicated[i,4] <- 6
+}
+
+# These are object pointers
+dv_true <- as_tibble(as_epi_archive(dv_duplicated,compactify=TRUE)$DT)
+dv_false <- as_tibble(as_epi_archive(dv_duplicated,compactify=FALSE)$DT)
+dv_null <- as_tibble(as_epi_archive(dv_duplicated,compactify=TRUE)$DT)
+
+# No compactify applied
+test_that("LOCF values are ignored", {
+  expect_identical(dv_duplicated,dv_false)
+})
+
+# compacity applied
+# No compactify applied
+test_that("LOCF values are taken out", {
+  dv_unique <- distinct(dv_false,percent_cli,.keep_all = TRUE)
+  expect_identical(dv_true,dv_null)
+  expect_identical(dv_null,dv_unique)
 })

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -3,20 +3,11 @@ library(data.table)
 library(dplyr)
 
 dt <- select(archive_cases_dv$DT,-case_rate)
-dt_unique <- dt
-dt_unique$percent_cli <- 0.1 * 1:160 + 20
 
 head(dt)
 arrange(dt,geo_value,time_value,version) %>% head()
 
 dt_full <- archive_cases_dv$DT
-mutate(dt_full, in_group =
-         tidyr::replace_na(
-           (geo_value == lag(geo_value) &
-              time_value == lag(time_value)),
-           FALSE
-         )
-)
 
 test_that("Input for compactify must be NULL or a boolean", {
   expect_error(as_epi_archive(dv_duplicated,compactify="no"))
@@ -30,12 +21,15 @@ test_that("Warning for LOCF with compactify as NULL", {
   expect_warning(as_epi_archive(dt,compactify=NULL))
 })
 
-test_that("LOCF values are ignored", {
+test_that("LOCF values are ignored with compactify=FALSE", {
   expect_identical(nrow(dt),nrow(dt_false))
 })
 
-test_that("LOCF values are taken out", {
-  dt_unique <- distinct(dt_false,case_rate,.keep_all = TRUE)
+test_that("LOCF values are taken out with compactify=TRUE", {
+  dt_unique <- dt_false %>%
+    distinct(percent_cli,.keep_all = TRUE) %>%
+    filter(!is.na(percent_cli))
+    
   expect_identical(dt_true,dt_null)
   expect_identical(dt_null,dt_unique)
 })

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -2,27 +2,40 @@ library(epiprocess)
 library(data.table)
 library(dplyr)
 
-dt <- filter(dv$DT,geo_value=="ca")
-dt <- select(dt,-case_rate)
+dt <- select(archive_cases_dv$DT,-case_rate)
+dt_unique <- dt
+dt_unique$percent_cli <- 0.1 * 1:160 + 20
+
+head(dt)
+arrange(dt,geo_value,time_value,version) %>% head()
+
+dt_full <- archive_cases_dv$DT
+mutate(dt_full, in_group =
+         tidyr::replace_na(
+           (geo_value == lag(geo_value) &
+              time_value == lag(time_value)),
+           FALSE
+         )
+)
 
 test_that("Input for compactify must be NULL or a boolean", {
   expect_error(as_epi_archive(dv_duplicated,compactify="no"))
 })
   
-dv_true <- as_tibble(as_epi_archive(dt,compactify=TRUE)$DT)
-dv_false <- as_tibble(as_epi_archive(dt,compactify=FALSE)$DT)
-dv_null <- as_tibble(as_epi_archive(dt,compactify=NULL)$DT)
+dt_true <- as_tibble(as_epi_archive(dt,compactify=TRUE)$DT)
+dt_false <- as_tibble(as_epi_archive(dt,compactify=FALSE)$DT)
+dt_null <- as_tibble(as_epi_archive(dt,compactify=NULL)$DT)
 
 test_that("Warning for LOCF with compactify as NULL", {
   expect_warning(as_epi_archive(dt,compactify=NULL))
 })
 
 test_that("LOCF values are ignored", {
-  expect_identical(nrow(dt),nrow(dv_false))
+  expect_identical(nrow(dt),nrow(dt_false))
 })
 
 test_that("LOCF values are taken out", {
-  dv_unique <- distinct(dv_false,percent_cli,.keep_all = TRUE)
-  expect_identical(dv_true,dv_null)
-  expect_identical(dv_null,dv_unique)
+  dt_unique <- distinct(dt_false,case_rate,.keep_all = TRUE)
+  expect_identical(dt_true,dt_null)
+  expect_identical(dt_null,dt_unique)
 })

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -1,0 +1,3 @@
+test_that("compactify gets an error", {
+  expect_equal(1,1)
+})

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -19,12 +19,14 @@ dv_duplicated <- dv
 for (i in 1:8) {
   dv_duplicated[i,4] <- 6
 }
-
-as_epi_archive(dv_duplicated,compactify=NULL)
-
+  
 dv_true <- as_tibble(as_epi_archive(dv_duplicated,compactify=TRUE)$DT)
 dv_false <- as_tibble(as_epi_archive(dv_duplicated,compactify=FALSE)$DT)
 dv_null <- as_tibble(as_epi_archive(dv_duplicated,compactify=NULL)$DT)
+
+test_that("Warning for LOCF with compactify as NULL", {
+  expect_warning(as_epi_archive(dv_duplicated,compactify=NULL))
+})
 
 test_that("LOCF values are ignored", {
   expect_identical(nrow(dv_duplicated),nrow(dv_false))

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -20,18 +20,14 @@ for (i in 1:5) {
   dv_duplicated[i,4] <- 6
 }
 
-# These are object pointers
 dv_true <- as_tibble(as_epi_archive(dv_duplicated,compactify=TRUE)$DT)
 dv_false <- as_tibble(as_epi_archive(dv_duplicated,compactify=FALSE)$DT)
-dv_null <- as_tibble(as_epi_archive(dv_duplicated,compactify=TRUE)$DT)
+dv_null <- as_tibble(as_epi_archive(dv_duplicated,compactify=NULL)$DT)
 
-# No compactify applied
 test_that("LOCF values are ignored", {
-  expect_identical(dv_duplicated,dv_false)
+  expect_identical(nrow(dv_duplicated),nrow(dv_false))
 })
 
-# compacity applied
-# No compactify applied
 test_that("LOCF values are taken out", {
   dv_unique <- distinct(dv_false,percent_cli,.keep_all = TRUE)
   expect_identical(dv_true,dv_null)

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -16,7 +16,7 @@ dv <- covidcast(
   select(geo_value, time_value, version = issue, percent_cli = value)
 
 dv_duplicated <- dv
-for (i in 1:5) {
+for (i in 1:8) {
   dv_duplicated[i,4] <- 6
 }
 

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -71,5 +71,5 @@ dt2$case_rate <- 1
 as_tibble(as_epi_archive(dt2,compactify=NULL)$DT)
 
 test_that("as_of works correctly",{
-  
+  # pls test
 })

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -2,17 +2,39 @@ library(epiprocess)
 library(data.table)
 library(dplyr)
 
-dt <- select(archive_cases_dv$DT,-case_rate)
-
-head(dt)
-arrange(dt,geo_value,time_value,version) %>% head()
-
-dt_full <- archive_cases_dv$DT
-
+dt <- archive_cases_dv$DT
 test_that("Input for compactify must be NULL or a boolean", {
   expect_error(as_epi_archive(dv_duplicated,compactify="no"))
 })
   
+dt <- filter(dt,geo_value == "ca")
+dt$percent_cli <- c(1:80)
+dt$case_rate <- c(1:80)
+
+row_replace <- function(row,x,y) {
+  dt[row,4] <- x
+  dt[row,5] <- y
+  dt
+}
+
+# Rows 11 and 12 correspond to different time_values
+dt <- row_replace(12,11,11) # Not LOCF
+
+# Rows 21 and 22 only differ in version
+dt <- row_replace(22,21,21) # LOCF
+
+# Row 39 comprises the first NA's
+dt <-row_replace(39,NA,NA) # Not LOCF
+
+# Row 40 has two NA's, just like its lag, row 39
+dt <- row_replace(40,NA,NA) # LOCF
+
+# Row 62's values already exist in row 15, but row 15 is not a preceding row
+dt <- row_replace(62,15,15) # Not LOCF
+
+# Row 73 only has one value carried over
+dt <- row_replace(74,73,74) # Not LOCF
+
 dt_true <- as_tibble(as_epi_archive(dt,compactify=TRUE)$DT)
 dt_false <- as_tibble(as_epi_archive(dt,compactify=FALSE)$DT)
 dt_null <- as_tibble(as_epi_archive(dt,compactify=NULL)$DT)
@@ -21,15 +43,17 @@ test_that("Warning for LOCF with compactify as NULL", {
   expect_warning(as_epi_archive(dt,compactify=NULL))
 })
 
+test_that("No warning when there is no LOCF", {
+  expect_warning(as_epi_archive(dt[1:10,],compactify=NULL),NA)
+})
+
 test_that("LOCF values are ignored with compactify=FALSE", {
   expect_identical(nrow(dt),nrow(dt_false))
 })
 
 test_that("LOCF values are taken out with compactify=TRUE", {
-  dt_unique <- dt_false %>%
-    distinct(percent_cli,.keep_all = TRUE) %>%
-    filter(!is.na(percent_cli))
-    
+  dt_test <- as_tibble(as_epi_archive(dt[-c(22,40),],compactify=FALSE)$DT)
+  
   expect_identical(dt_true,dt_null)
-  expect_identical(dt_null,dt_unique)
+  expect_identical(dt_null,dt_test)
 })

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -17,6 +17,9 @@ row_replace <- function(row,x,y) {
   dt
 }
 
+# Rows 1 should not be eliminated even if NA
+dt <- row_replace(1,NA,NA) # Not LOCF
+
 # Rows 11 and 12 correspond to different time_values
 dt <- row_replace(12,11,11) # Not LOCF
 
@@ -60,3 +63,9 @@ test_that("LOCF values are taken out with compactify=TRUE", {
   expect_identical(dt_true,dt_null)
   expect_identical(dt_null,dt_test)
 })
+
+dt2 <- dt
+dt2$percent_cli <- 1
+dt2$case_rate <- 1
+
+as_tibble(as_epi_archive(dt2,compactify=NULL)$DT)

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -64,12 +64,16 @@ test_that("LOCF values are taken out with compactify=TRUE", {
   expect_identical(dt_null,dt_test)
 })
 
-dt2 <- dt
-dt2$percent_cli <- 1
-dt2$case_rate <- 1
-
-as_tibble(as_epi_archive(dt2,compactify=NULL)$DT)
-
 test_that("as_of works correctly",{
-  # pls test
+  ea_true <- as_epi_archive(dt,compactify=TRUE)
+  ea_false <- as_epi_archive(dt,compactify=FALSE)
+  
+  epix_as_of(ea_true,max(ea_true$DT$version))
+  
+  # Row 22, an LOCF row corresponding to the latest version, but for the
+  # date 2020-06-02, is omitted in ea_true
+  as_of_true  <- ea_true$as_of(max(ea_true$DT$version))
+  as_of_false <- ea_false$as_of(max(ea_false$DT$version))
+  
+  expect_identical(as_of_true,as_of_false)
 })

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -69,3 +69,7 @@ dt2$percent_cli <- 1
 dt2$case_rate <- 1
 
 as_tibble(as_epi_archive(dt2,compactify=NULL)$DT)
+
+test_that("as_of works correctly",{
+  
+})

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -20,6 +20,8 @@ for (i in 1:5) {
   dv_duplicated[i,4] <- 6
 }
 
+as_epi_archive(dv_duplicated,compactify=NULL)
+
 dv_true <- as_tibble(as_epi_archive(dv_duplicated,compactify=TRUE)$DT)
 dv_false <- as_tibble(as_epi_archive(dv_duplicated,compactify=FALSE)$DT)
 dv_null <- as_tibble(as_epi_archive(dv_duplicated,compactify=NULL)$DT)

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -2,6 +2,8 @@ library(epiprocess)
 library(data.table)
 library(dplyr)
 
+
+
 dt <- archive_cases_dv$DT
 test_that("Input for compactify must be NULL or a boolean", {
   expect_error(as_epi_archive(dv_duplicated,compactify="no"))
@@ -19,6 +21,11 @@ row_replace <- function(row,x,y) {
 
 # Rows 1 should not be eliminated even if NA
 dt <- row_replace(1,NA,NA) # Not LOCF
+
+# NOTE! We are assuming that there are no NA's in geo_value, time_value,
+# and version. Even though compactify may erroneously remove the first row
+# if it has all NA's, we are not testing this behaviour for now as this dataset
+# has problems beyond the scope of this test
 
 # Rows 11 and 12 correspond to different time_values
 dt <- row_replace(12,11,11) # Not LOCF
@@ -77,3 +84,6 @@ test_that("as_of utilizes LOCF even after removal of LOCF values",{
   
   expect_identical(as_of_true,as_of_false)
 })
+
+
+

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -20,8 +20,11 @@ row_replace <- function(row,x,y) {
 # Rows 11 and 12 correspond to different time_values
 dt <- row_replace(12,11,11) # Not LOCF
 
+# Rows 20 and 21 only differ in version
+dt <- row_replace(21,20,20) # LOCF
+
 # Rows 21 and 22 only differ in version
-dt <- row_replace(22,21,21) # LOCF
+dt <- row_replace(22,20,20) # LOCF
 
 # Row 39 comprises the first NA's
 dt <-row_replace(39,NA,NA) # Not LOCF
@@ -52,7 +55,7 @@ test_that("LOCF values are ignored with compactify=FALSE", {
 })
 
 test_that("LOCF values are taken out with compactify=TRUE", {
-  dt_test <- as_tibble(as_epi_archive(dt[-c(22,40),],compactify=FALSE)$DT)
+  dt_test <- as_tibble(as_epi_archive(dt[-c(21,22,40),],compactify=FALSE)$DT)
   
   expect_identical(dt_true,dt_null)
   expect_identical(dt_null,dt_test)

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -64,7 +64,7 @@ test_that("LOCF values are taken out with compactify=TRUE", {
   expect_identical(dt_null,dt_test)
 })
 
-test_that("as_of works correctly",{
+test_that("as_of utilizes LOCF even after removal of LOCF values",{
   ea_true <- as_epi_archive(dt,compactify=TRUE)
   ea_false <- as_epi_archive(dt,compactify=FALSE)
   

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -2,8 +2,6 @@ library(epiprocess)
 library(data.table)
 library(dplyr)
 
-
-
 dt <- archive_cases_dv$DT
 test_that("Input for compactify must be NULL or a boolean", {
   expect_error(as_epi_archive(dv_duplicated,compactify="no"))
@@ -84,6 +82,3 @@ test_that("as_of utilizes LOCF even after removal of LOCF values",{
   
   expect_identical(as_of_true,as_of_false)
 })
-
-
-

--- a/vignettes/archive.Rmd
+++ b/vignettes/archive.Rmd
@@ -111,9 +111,14 @@ x$clone()`. You can read more about reference semantics in Hadley Wickham's
 
 ## Removing LOCF data to save space
 
-We need not even include LOCF values, as they use up extra space. The
-`compactify` argument is a way of removing LOCF values, as they use up extra
-space that can slow down computational time. There are three
+We need not even store rows that look like the last observation carried forward,
+as they use up extra space. Furthermore, we already apply LOCF in the
+epi_archive-related functions, such that the results should be the same with or
+without the rows, aas long as use code does not rely on directly modifying
+epi_archive's fields in a way that expects all the original records and breaks
+if they are trimmed down.
+ 
+There are three
 different values that can be asssigned to `compactify`:
 
 * No argument: Does not put in LOCF values, and prints a list of LOCF values
@@ -126,15 +131,6 @@ For this example, we have one chart using LOCF values, while another doesn't
 use them to illustrate LOCF.
 
 <!-- PROVIDE AN EXAMPLE HERE -->
-
-We need not even store rows that just look like the last observation carried
-forward (LOCF), as they use up extra space, and we apply LOCF in
-epi_archive-related functions, such that the results should be the same with or
-without these rows, as long as use code does not rely on directly modifying the
-epi_archive's fields in a way that expects all the original records and breaks
-if they are trimmed down.
-
-<!-- PLS UPDATE ABOVE AS IT WAS COPY-PASTED FROM LOGAN'S COMMENT AS REFERENCE>
  
 ## Some details on metadata
 
@@ -146,7 +142,7 @@ object:
 * `additional_metadata`: list of additional metadata for the data archive.
 * `compactify`: TRUE eliminates redundant entries using LOCF for efficiency;
 no entry also brings up a message to indicate which columns should be removed
-for efficiency; and FALSE does not eliminate redundant entries
+for efficiency; and FALSE does not eliminate redundant entries.
 
 Metadata for an `epi_archive` object `x` can be accessed (and altered) directly,
 as in `x$geo_type` or `x$time_type`, etc. Just like `as_epi_df()`, the function

--- a/vignettes/archive.Rmd
+++ b/vignettes/archive.Rmd
@@ -147,15 +147,21 @@ object:
 * `geo_type`: the type for the geo values.
 * `time_type`: the type for the time values.
 * `additional_metadata`: list of additional metadata for the data archive.
-* `compactify`: TRUE eliminates redundant entries using LOCF for efficiency;
-no entry also brings up a message to indicate which columns should be removed
-for efficiency; and FALSE does not eliminate redundant entries.
 
 Metadata for an `epi_archive` object `x` can be accessed (and altered) directly,
 as in `x$geo_type` or `x$time_type`, etc. Just like `as_epi_df()`, the function
 `as_epi_archive()` attempts to guess metadata fields when an `epi_archive`
 object is instantiated, if they are not explicitly specified in the function
 call (as it did in the case above).
+
+Note that `compactify` is NOT metadata and is an argument passed when creating
+the dataset, without being stored in the end:
+
+```{r,message=FALSE}
+# `dt` here is taken from the tests
+as_epi_archive(archive_cases_dv$DT,compactify=TRUE)$geo_type # "state"
+as_epi_archive(archive_cases_dv$DT,compactify=TRUE)$compactify # NULL
+```
 
 ## Producing snapshots in `epi_df` form
 

--- a/vignettes/archive.Rmd
+++ b/vignettes/archive.Rmd
@@ -126,6 +126,15 @@ For this example, we have one chart using LOCF values, while another doesn't
 use them to illustrate LOCF.
 
 <!-- PROVIDE AN EXAMPLE HERE -->
+
+We need not even store rows that just look like the last observation carried
+forward (LOCF), as they use up extra space, and we apply LOCF in
+epi_archive-related functions, such that the results should be the same with or
+without these rows, as long as use code does not rely on directly modifying the
+epi_archive's fields in a way that expects all the original records and breaks
+if they are trimmed down.
+
+<!-- PLS UPDATE ABOVE AS IT WAS COPY-PASTED FROM LOGAN'S COMMENT AS REFERENCE>
  
 ## Some details on metadata
 

--- a/vignettes/archive.Rmd
+++ b/vignettes/archive.Rmd
@@ -154,7 +154,7 @@ as in `x$geo_type` or `x$time_type`, etc. Just like `as_epi_df()`, the function
 object is instantiated, if they are not explicitly specified in the function
 call (as it did in the case above).
 
-Note that `compactify` is NOT metadata and is an argument passed when creating
+Note that `compactify` is **NOT** metadata and is an argument passed when creating
 the dataset, without being stored in the end:
 
 ```{r,message=FALSE}

--- a/vignettes/archive.Rmd
+++ b/vignettes/archive.Rmd
@@ -108,6 +108,24 @@ x$DT$percent_cli[1] <- original_value
 To make a copy, we can use the `clone()` method for an R6 class, as in `y <-
 x$clone()`. You can read more about reference semantics in Hadley Wickham's
 [Advanced R](https://adv-r.hadley.nz/r6.html#r6-semantics) book.
+
+## Removing LOCF data to save space
+
+We need not even include LOCF values, as they use up extra space. The
+`compactify` argument is a way of removing LOCF values, as they use up extra
+space that can slow down computational time. There are three
+different values that can be asssigned to `compactify`:
+
+* No argument: Does not put in LOCF values, and prints a list of LOCF values
+that have been omitted but could have been placed.
+* `TRUE`: Does not put in LOCF values, but doesn't print anything relating
+to which values have been omitted.
+* `FALSE`: Includes LOCF values.
+
+For this example, we have one chart using LOCF values, while another doesn't
+use them to illustrate LOCF.
+
+<!-- PROVIDE AN EXAMPLE HERE -->
  
 ## Some details on metadata
 
@@ -202,10 +220,6 @@ quite as dramatically. Modeling the revision process, which is often called
 
 <!-- todo: refer to some project/code? perhaps we should think about writing a
  function in `epiprocess` or even a separate package? -->
- 
-Finally, we can use compactify to remove variables that match the LOCF (last
-observation carried forward)
-
 
 ## Merging `epi_archive` objects 
 

--- a/vignettes/archive.Rmd
+++ b/vignettes/archive.Rmd
@@ -117,6 +117,9 @@ object:
 * `geo_type`: the type for the geo values.
 * `time_type`: the type for the time values.
 * `additional_metadata`: list of additional metadata for the data archive.
+* `compactify`: TRUE eliminates redundant entries using LOCF for efficiency;
+no entry also brings up a message to indicate which columns should be removed
+for efficiency; and FALSE does not eliminate redundant entries
 
 Metadata for an `epi_archive` object `x` can be accessed (and altered) directly,
 as in `x$geo_type` or `x$time_type`, etc. Just like `as_epi_df()`, the function
@@ -199,6 +202,10 @@ quite as dramatically. Modeling the revision process, which is often called
 
 <!-- todo: refer to some project/code? perhaps we should think about writing a
  function in `epiprocess` or even a separate package? -->
+ 
+Finally, we can use compactify to remove variables that match the LOCF (last
+observation carried forward)
+
 
 ## Merging `epi_archive` objects 
 

--- a/vignettes/archive.Rmd
+++ b/vignettes/archive.Rmd
@@ -128,9 +128,16 @@ to which values have been omitted.
 * `FALSE`: Includes LOCF values.
 
 For this example, we have one chart using LOCF values, while another doesn't
-use them to illustrate LOCF.
+use them to illustrate LOCF. Notice how the head of the first dataset differs
+from the second from the third value included.
 
-<!-- PROVIDE AN EXAMPLE HERE -->
+```{r}
+locf_omitted <- as_epi_archive(archive_cases_dv$DT)
+locf_included <- as_epi_archive(archive_cases_dv$DT,compactify = FALSE)
+
+head(locf_omitted$DT)
+head(locf_included$DT)
+```
  
 ## Some details on metadata
 


### PR DESCRIPTION
Note that the first row may be erroneously removed if all fields (except `version`) are NA's. However, the handling of NA's is beyond the scope of this branch and rectification of compactify.