### PR TITLE
Mentioned `epi_archive` functionality and changed "over space and time" in package description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,9 +15,10 @@ Authors@R: c(
     person("Dmitry", "Shemetov", role = "ctb"),
     person("Ryan", "Tibshirani", , "ryantibs@cmu.edu", role = c("aut", "cre"))
   )
-Description: This package introduces a common data structure for
-    epidemiological data sets measured over space and time, and offers
-    associated utilities to perform basic signal processing tasks.
+Description: This package introduces a common data structure for epidemiological
+    data reported by location and time, provides another data structure to
+    work with revisions to these data sets over time, and offers associated
+    utilities to perform basic signal processing tasks.
 License: MIT + file LICENSE
 Imports: 
     data.table,

--- a/man/archive_cases_dv_subset.Rd
+++ b/man/archive_cases_dv_subset.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{archive_cases_dv_subset}
 \alias{archive_cases_dv_subset}
-\title{Subset of daily doctor visits and cases from California, Florida, Texas, and New York in archive format}
+\title{Subset of daily doctor visits and cases in archive format}
 \format{
 An \code{epi_archive} data format. The data table DT has 129,638 rows and 5 columns:
 \describe{
@@ -35,6 +35,7 @@ This data source is based on information about outpatient visits,
 provided to us by health system partners, and also contains confirmed
 COVID-19 cases based on reports made available by the Center for
 Systems Science and Engineering at Johns Hopkins University.
-This example data ranges from June 1, 2020 to Dec 1, 2021, and is also limited to California, Florida, Texas, and New York.
+This example data ranges from June 1, 2020 to Dec 1, 2021, and
+is also limited to California, Florida, Texas, and New York.
 }
 \keyword{datasets}

--- a/man/incidence_num_outlier_example.Rd
+++ b/man/incidence_num_outlier_example.Rd
@@ -32,7 +32,8 @@ incidence_num_outlier_example
 This data source of confirmed COVID-19 cases
 is based on reports made available by the Center for
 Systems Science and Engineering at Johns Hopkins University.
-This example data is a snapshot as of Oct 28, 2021 and captures the cases from June 1, 2020 to May 31, 2021
+This example data is a snapshot as of Oct 28, 2021 and captures the cases
+from June 1, 2020 to May 31, 2021
 and is limited to California and Florida.
 }
 \keyword{datasets}

--- a/man/jhu_csse_county_level_subset.Rd
+++ b/man/jhu_csse_county_level_subset.Rd
@@ -33,6 +33,7 @@ jhu_csse_county_level_subset
 This data source of confirmed COVID-19 cases and deaths
 is based on reports made available by the Center for
 Systems Science and Engineering at Johns Hopkins University.
-This example data ranges from Mar 1, 2020 to Dec 31, 2021, and is limited to Massachusetts and Vermont.
+This example data ranges from Mar 1, 2020 to Dec 31, 2021,
+and is limited to Massachusetts and Vermont.
 }
 \keyword{datasets}

--- a/man/jhu_csse_daily_subset.Rd
+++ b/man/jhu_csse_daily_subset.Rd
@@ -3,28 +3,42 @@
 \docType{data}
 \name{jhu_csse_daily_subset}
 \alias{jhu_csse_daily_subset}
-\title{Subset of JHU daily cases and deaths from California, Florida, Texas, New York, Georgia, and Pennsylvania}
+\title{Subset of JHU daily state cases and deaths}
 \format{
 A tibble with 4026 rows and 6 variables:
 \describe{
-\item{geo_value}{the geographic value associated with each row of measurements.}
+\item{geo_value}{the geographic value associated with each row
+of measurements.}
 \item{time_value}{the time value associated with each row of measurements.}
-\item{case_rate_7d_av}{7-day average signal of number of new confirmed COVID-19 cases per 100,000 population, daily}
-\item{death_rate_7d_av}{7-day average signal of number of new confirmed deaths due to COVID-19 per 100,000 population, daily}
+\item{case_rate_7d_av}{7-day average signal of number of new
+confirmed COVID-19 cases per 100,000 population, daily}
+\item{death_rate_7d_av}{7-day average signal of number of new confirmed
+deaths due to COVID-19 per 100,000 population, daily}
 \item{cases}{Number of new confirmed COVID-19 cases, daily}
-\item{cases_7d_av}{7-day average signal of number of new confirmed COVID-19 cases, daily}
+\item{cases_7d_av}{7-day average signal of number of new confirmed
+COVID-19 cases, daily}
 }
 }
 \source{
-This object contains a modified part of the \href{https://github.com/CSSEGISandData/COVID-19}{COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University} as \href{https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html}{republished in the COVIDcast Epidata API}. This data set is licensed under the terms of the
+This object contains a modified part of the
+\href{https://github.com/CSSEGISandData/COVID-19}{COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University}
+as \href{https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html}{republished in the COVIDcast Epidata API}.
+This data set is licensed under the terms of the
 \href{https://creativecommons.org/licenses/by/4.0/}{Creative Commons Attribution 4.0 International license}
-by the Johns Hopkins University on behalf of its Center for Systems Science in Engineering.
-Copyright Johns Hopkins University 2020.
+by the Johns Hopkins University on behalf of its Center for Systems Science
+in Engineering. Copyright Johns Hopkins University 2020.
 
 Modifications:
 \itemize{
-\item \href{https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html}{From the COVIDcast Epidata API}: These signals are taken directly from the JHU CSSE \href{https://github.com/CSSEGISandData/COVID-19}{COVID-19 GitHub repository} without changes. The 7-day average signals are computed by Delphi by calculating moving averages of the preceding 7 days, so the signal for June 7 is the average of the underlying data for June 1 through 7, inclusive.
-\item Furthermore, the data has been limited to a very small number of rows, the signal names slightly altered, and formatted into a tibble.
+\item \href{https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html}{From the COVIDcast Epidata API}:
+These signals are taken directly from the JHU CSSE
+\href{https://github.com/CSSEGISandData/COVID-19}{COVID-19 GitHub repository}
+without changes. The 7-day average signals are computed by Delphi by
+calculating moving averages of the preceding 7 days, so the signal for
+June 7 is the average of the underlying data for June 1 through 7,
+inclusive.
+\item Furthermore, the data has been limited to a very small number of rows,
+the signal names slightly altered, and formatted into a tibble.
 }
 }
 \usage{
@@ -34,6 +48,7 @@ jhu_csse_daily_subset
 This data source of confirmed COVID-19 cases and deaths
 is based on reports made available by the Center for
 Systems Science and Engineering at Johns Hopkins University.
-This example data ranges from Mar 1, 2020 to Dec 31, 2021, and is limited to California, Florida, Texas, New York, Georgia, and Pennsylvania.
+This example data ranges from Mar 1, 2020 to Dec 31, 2021, and is limited to
+California, Florida, Texas, New York, Georgia, and Pennsylvania.
 }
 \keyword{datasets}


### PR DESCRIPTION
In description, mentioned `epi_archive` functionality (as "provides another data structure to
    work with revisions to these data sets over time") and changed  "epidemiological data sets measured over space and time" -> "epidemiological data reported by location and time" as originally written in the [issue](https://github.com/cmu-delphi/epiprocess/issues/80).