### PR TITLE
Removed time filter in relation to version in `as_of`

### DIFF
--- a/R/archive.R
+++ b/R/archive.R
@@ -189,7 +189,7 @@ epi_archive =
 #' @description Generates a snapshot in `epi_df` format as of a given version.
 #'   See the documentation for the wrapper function `epix_as_of()` for details.
 #' @importFrom data.table between key
-          as_of = function(max_version) {
+          as_of = function(max_version, min_time_value = -Inf) {
             # Self max version and other keys
             self_max = max(self$DT$version)
             other_keys = setdiff(key(self$DT),
@@ -213,7 +213,8 @@ epi_archive =
             # Filter by version and return
             return(
               # Make sure to use data.table ways of filtering and selecting
-              self$DT[version <= max_version, ] %>%
+              self$DT[time_value >= min_time_value &
+                        version <= max_version, ] %>%
               unique(by = c("geo_value", "time_value", other_keys),
                      fromLast = TRUE) %>%
               tibble::as_tibble() %>%

--- a/R/archive.R
+++ b/R/archive.R
@@ -189,7 +189,7 @@ epi_archive =
 #' @description Generates a snapshot in `epi_df` format as of a given version.
 #'   See the documentation for the wrapper function `epix_as_of()` for details.
 #' @importFrom data.table between key
-          as_of = function(max_version, min_time_value = -Inf) {
+          as_of = function(max_version) {
             # Self max version and other keys
             self_max = max(self$DT$version)
             other_keys = setdiff(key(self$DT),
@@ -213,10 +213,7 @@ epi_archive =
             # Filter by version and return
             return(
               # Make sure to use data.table ways of filtering and selecting
-              self$DT[between(time_value,
-                              min_time_value,
-                              max_version) &
-                      version <= max_version, ] %>%
+              self$DT[version <= max_version, ] %>%
               unique(by = c("geo_value", "time_value", other_keys),
                      fromLast = TRUE) %>%
               tibble::as_tibble() %>%

--- a/R/methods-epi_archive.R
+++ b/R/methods-epi_archive.R
@@ -34,9 +34,9 @@
 #' 
 #' # no warning shown
 #' epix_as_of(archive_cases_dv_subset, max_version = as.Date("2020-06-10"))          
-epix_as_of = function(x, max_version) {
+epix_as_of = function(x, max_version, min_time_value = -Inf) {
   if (!inherits(x, "epi_archive")) Abort("`x` must be of class `epi_archive`.")
-  return(x$as_of(max_version))
+  return(x$as_of(max_version, min_time_value))
 }
 
 #' Merge two `epi_archive` objects

--- a/R/methods-epi_archive.R
+++ b/R/methods-epi_archive.R
@@ -34,9 +34,9 @@
 #' 
 #' # no warning shown
 #' epix_as_of(archive_cases_dv_subset, max_version = as.Date("2020-06-10"))          
-epix_as_of = function(x, max_version, min_time_value = -Inf) {
+epix_as_of = function(x, max_version) {
   if (!inherits(x, "epi_archive")) Abort("`x` must be of class `epi_archive`.")
-  return(x$as_of(max_version, min_time_value))
+  return(x$as_of(max_version))
 }
 
 #' Merge two `epi_archive` objects


### PR DESCRIPTION
As per [issue 90](https://github.com/cmu-delphi/epiprocess/issues/90), removed time filter relative to the version value in `as_of` function.