### PR TITLE
Updated `epi_slide` examples to ensure new col is printed

### DIFF
--- a/R/slide.R
+++ b/R/slide.R
@@ -95,7 +95,7 @@
 #'   epi_slide(cases_7dav = mean(cases), n = 7, 
 #'             align = "right") %>% 
 #'   # rmv a nonessential var. to ensure new col is printed
-#'   dplyr::select(-c(death_rate_7d_av))
+#'   dplyr::select(-death_rate_7d_av) 
 #'  
 #'  # slide a left-aligned 7-day average
 #'   jhu_csse_daily_subset %>%
@@ -103,7 +103,7 @@
 #'   epi_slide(cases_7dav = mean(cases), n = 7, 
 #'             align = "left") %>% 
 #'   # rmv a nonessential var. to ensure new col is printed
-#'   dplyr::select(-c(death_rate_7d_av))
+#'   dplyr::select(-death_rate_7d_av) 
 #'  
 #'  # nested new columns
 #'  jhu_csse_daily_subset %>% 

--- a/R/slide.R
+++ b/R/slide.R
@@ -93,13 +93,17 @@
 #'   jhu_csse_daily_subset %>%
 #'   group_by(geo_value) %>%
 #'   epi_slide(cases_7dav = mean(cases), n = 7, 
-#'             align = "right")
+#'             align = "right") %>% 
+#'   # rmv a nonessential var. to ensure new col is printed
+#'   dplyr::select(-c(death_rate_7d_av))
 #'  
 #'  # slide a left-aligned 7-day average
 #'   jhu_csse_daily_subset %>%
 #'   group_by(geo_value) %>%
 #'   epi_slide(cases_7dav = mean(cases), n = 7, 
-#'             align = "left")
+#'             align = "left") %>% 
+#'   # rmv a nonessential var. to ensure new col is printed
+#'   dplyr::select(-c(death_rate_7d_av))
 #'  
 #'  # nested new columns
 #'  jhu_csse_daily_subset %>% 

--- a/man/epi_slide.Rd
+++ b/man/epi_slide.Rd
@@ -121,13 +121,17 @@ through the \code{new_col_name} argument.
   jhu_csse_daily_subset \%>\%
   group_by(geo_value) \%>\%
   epi_slide(cases_7dav = mean(cases), n = 7, 
-            align = "right")
+            align = "right") \%>\% 
+  # rmv a nonessential var. to ensure new col is printed
+  dplyr::select(-c(death_rate_7d_av))
  
  # slide a left-aligned 7-day average
   jhu_csse_daily_subset \%>\%
   group_by(geo_value) \%>\%
   epi_slide(cases_7dav = mean(cases), n = 7, 
-            align = "left")
+            align = "left") \%>\% 
+  # rmv a nonessential var. to ensure new col is printed
+  dplyr::select(-c(death_rate_7d_av))
  
  # nested new columns
  jhu_csse_daily_subset \%>\% 

--- a/man/epi_slide.Rd
+++ b/man/epi_slide.Rd
@@ -123,7 +123,7 @@ through the \code{new_col_name} argument.
   epi_slide(cases_7dav = mean(cases), n = 7, 
             align = "right") \%>\% 
   # rmv a nonessential var. to ensure new col is printed
-  dplyr::select(-c(death_rate_7d_av))
+  dplyr::select(-death_rate_7d_av) 
  
  # slide a left-aligned 7-day average
   jhu_csse_daily_subset \%>\%
@@ -131,7 +131,7 @@ through the \code{new_col_name} argument.
   epi_slide(cases_7dav = mean(cases), n = 7, 
             align = "left") \%>\% 
   # rmv a nonessential var. to ensure new col is printed
-  dplyr::select(-c(death_rate_7d_av))
+  dplyr::select(-death_rate_7d_av) 
  
  # nested new columns
  jhu_csse_daily_subset \%>\% 


### PR DESCRIPTION
As per our discussion @brookslogan, updated the `epi_slide` examples to remove a nonessential var in the output so that the new col is ensured to be printed when the usual setting of `getOption("width")` of 80 is used in R or RStudio. Should be good to go now.