### PR TITLE
Ignore `NA`s when printing an archive's min/max `time_value`

### DIFF
--- a/R/archive.R
+++ b/R/archive.R
@@ -188,28 +188,16 @@ epi_archive =
               })
             }
             cat("----------\n")
+            if (length(self$DT$time_value) == 0 || all(is.na(self$DT$time_value)) || all(is.nan(self$DT$time_value))) {
+              min_time = max_time = NA
+            } else {
+              min_time = Min(self$DT$time_value)
+              max_time = Max(self$DT$time_value)
+            }
             cat(sprintf("* %-14s = %s\n", "min time value",
-                        tryCatch({
-                          Min(self$DT$time_value)
-                        },
-                        warning = function(w) {
-                          if (w$message != "no non-missing arguments to min; returning Inf") {
-                            warning(w)
-                          }
-                          NA
-                        }
-                        )))
+                          min_time))
             cat(sprintf("* %-14s = %s\n", "max time value",
-                        tryCatch({
-                          Max(self$DT$time_value)
-                        },
-                        warning = function(w) {
-                          if (w$message != "no non-missing arguments to max; returning -Inf") {
-                            warning(w)
-                          }
-                          NA
-                        }
-                        )))
+                          max_time))
             cat(sprintf("* %-14s = %s\n", "min version",
                         min(self$DT$version)))
             cat(sprintf("* %-14s = %s\n", "max version",

--- a/R/archive.R
+++ b/R/archive.R
@@ -189,9 +189,27 @@ epi_archive =
             }
             cat("----------\n")
             cat(sprintf("* %-14s = %s\n", "min time value",
-                        Min(self$DT$time_value)))
+                        tryCatch({
+                          Min(self$DT$time_value)
+                        },
+                        warning = function(w) {
+                          if (w$message != "no non-missing arguments to min; returning Inf") {
+                            warning(w)
+                          }
+                          NA
+                        }
+                        )))
             cat(sprintf("* %-14s = %s\n", "max time value",
-                        Max(self$DT$time_value)))
+                        tryCatch({
+                          Max(self$DT$time_value)
+                        },
+                        warning = function(w) {
+                          if (w$message != "no non-missing arguments to max; returning -Inf") {
+                            warning(w)
+                          }
+                          NA
+                        }
+                        )))
             cat(sprintf("* %-14s = %s\n", "min version",
                         min(self$DT$version)))
             cat(sprintf("* %-14s = %s\n", "max version",

--- a/R/archive.R
+++ b/R/archive.R
@@ -188,7 +188,7 @@ epi_archive =
               })
             }
             cat("----------\n")
-            if (length(self$DT$time_value) == 0 || all(is.na(self$DT$time_value)) || all(is.nan(self$DT$time_value))) {
+            if (length(self$DT$time_value) == 0 || all(is.na(self$DT$time_value))) {
               min_time = max_time = NA
             } else {
               min_time = Min(self$DT$time_value)

--- a/R/archive.R
+++ b/R/archive.R
@@ -189,9 +189,9 @@ epi_archive =
             }
             cat("----------\n")
             cat(sprintf("* %-14s = %s\n", "min time value",
-                        min(self$DT$time_value)))
+                        Min(self$DT$time_value)))
             cat(sprintf("* %-14s = %s\n", "max time value",
-                        max(self$DT$time_value)))
+                        Max(self$DT$time_value)))
             cat(sprintf("* %-14s = %s\n", "min version",
                         min(self$DT$version)))
             cat(sprintf("* %-14s = %s\n", "max version",

--- a/man/as_epi_df.Rd
+++ b/man/as_epi_df.Rd
@@ -51,9 +51,9 @@ examples.
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{epi_df}: Simply returns the \code{epi_df} object unchanged.
+\item \code{as_epi_df(epi_df)}: Simply returns the \code{epi_df} object unchanged.
 
-\item \code{tbl_df}: The input tibble \code{x} must contain the columns
+\item \code{as_epi_df(tbl_df)}: The input tibble \code{x} must contain the columns
 \code{geo_value} and \code{time_value}. All other columns will be preserved as is,
 and treated as measured variables. If \code{as_of} is missing, then the function
 will try to guess it from an \code{as_of}, \code{issue}, or \code{version} column of \code{x}
@@ -61,14 +61,14 @@ will try to guess it from an \code{as_of}, \code{issue}, or \code{version} colum
 (stored in its attributes); if this fails, then the current day-time will
 be used.
 
-\item \code{data.frame}: Works analogously to \code{as_epi_df.tbl_df()}.
+\item \code{as_epi_df(data.frame)}: Works analogously to \code{as_epi_df.tbl_df()}.
 
-\item \code{tbl_ts}: Works analogously to \code{as_epi_df.tbl_df()}, except that
+\item \code{as_epi_df(tbl_ts)}: Works analogously to \code{as_epi_df.tbl_df()}, except that
 the \code{tbl_ts} class is dropped, and any key variables (other than
 "geo_value") are added to the metadata of the returned object, under the
 \code{other_keys} field.
-}}
 
+}}
 \examples{
 # Convert a `tsibble` that has county code as an extra key
 # Notice that county code should be a character string to preserve any leading zeroes


### PR DESCRIPTION
### Description
Toggle on the `na.rm` option (via the custom `Min` and `Max` functions) so even if an `epi_archive`'s `time_value` field contains some missing values (`NA`) printed min/max values are still useful. Prints `NA` if _all_ `time_value`s are missing and "no non-missing arguments" warning is raised, or if an un-caught warning occurs.

### Changes
- `R/archive.R` - added `na.rm` setting and try-catch to handle all-missing case.
- `man/as_epi_df.Rd` - not my changes, showed up when I re-`document()`ed

### Fixes
Closes https://github.com/cmu-delphi/epiprocess/issues/106