### PR TITLE
[Issue 182] Update `epi_df` examples, check `additional_metadata` type at construction

### DIFF
--- a/R/epi_df.R
+++ b/R/epi_df.R
@@ -106,8 +106,8 @@ NULL
 #' @param additional_metadata List of additional metadata to attach to the
 #'   `epi_df` object. The metadata will have `geo_type`, `time_type`, and
 #'   `as_of` fields; named entries from the passed list will be included as
-#'   well. If your tibble has additional keys, be sure to specify them 
-#'   in the `other_keys` component of `additional_metadata`. 
+#'   well. If your tibble has additional keys, be sure to specify them as a
+#'   character vector in the `other_keys` component of `additional_metadata`. 
 #' @param ... Additional arguments passed to methods.
 #' @return An `epi_df` object.
 #' 
@@ -190,8 +190,8 @@ new_epi_df = function(x = tibble::tibble(), geo_type, time_type, as_of,
 #' @param additional_metadata List of additional metadata to attach to the
 #'   `epi_df` object. The metadata will have `geo_type`, `time_type`, and
 #'   `as_of` fields; named entries from the passed list will be included as
-#'   well. If your tibble has additional keys, be sure to specify them 
-#'   in the `other_keys` component of `additional_metadata`.
+#'   well. If your tibble has additional keys, be sure to specify them as a
+#'   character vector in the `other_keys` component of `additional_metadata`.
 #' @param ... Additional arguments passed to methods.
 #' @return An `epi_df` object.
 #'

--- a/R/epi_df.R
+++ b/R/epi_df.R
@@ -117,7 +117,11 @@ new_epi_df = function(x = tibble::tibble(), geo_type, time_type, as_of,
   if (!is.data.frame(x)) {
     Abort("`x` must be a data frame.")
   }
-  
+    
+  if (!is.list(additional_metadata)) {
+    Abort("`additional_metadata` must be a list type.")
+  }
+
   # If geo type is missing, then try to guess it
   if (missing(geo_type)) {
     geo_type = guess_geo_type(x$geo_value)
@@ -230,7 +234,7 @@ new_epi_df = function(x = tibble::tibble(), geo_type, time_type, as_of,
 #' 
 #' ex2 <- ex2_input %>% dplyr::rename(geo_value = state, time_value = reported_date) %>%
 #'   as_epi_df(geo_type = "state", as_of = "2020-06-03", 
-#'             additional_metadata = c(other_keys = "pol"))
+#'             additional_metadata = list(other_keys = "pol")) 
 #' 
 #' attr(ex2,"metadata")
 #' 
@@ -244,8 +248,10 @@ new_epi_df = function(x = tibble::tibble(), geo_type, time_type, as_of,
 #' 
 #' ex3 <- ex3_input %>% 
 #'   tsibble::as_tsibble() %>% # needed to add the additional metadata
-#'   dplyr::mutate(state = rep("MA",6)) %>%
-#'   as_epi_df(additional_metadata = c(other_keys = "state"))
+#'   dplyr::mutate(
+#'     state = rep("MA",6),
+#'     pol = rep(c("blue", "swing", "swing"), each = 2)) %>% # 2 extra keys
+#'   as_epi_df(additional_metadata = list(other_keys = "state", "pol")) %>%
 #' 
 #' attr(ex3,"metadata")
 as_epi_df = function(x, ...) {

--- a/R/epi_df.R
+++ b/R/epi_df.R
@@ -251,7 +251,7 @@ new_epi_df = function(x = tibble::tibble(), geo_type, time_type, as_of,
 #'   dplyr::mutate(
 #'     state = rep("MA",6),
 #'     pol = rep(c("blue", "swing", "swing"), each = 2)) %>% # 2 extra keys
-#'   as_epi_df(additional_metadata = list(other_keys = "state", "pol")) 
+#'   as_epi_df(additional_metadata = list(other_keys = c("state", "pol")))
 #' 
 #' attr(ex3,"metadata")
 as_epi_df = function(x, ...) {

--- a/R/epi_df.R
+++ b/R/epi_df.R
@@ -251,7 +251,7 @@ new_epi_df = function(x = tibble::tibble(), geo_type, time_type, as_of,
 #'   dplyr::mutate(
 #'     state = rep("MA",6),
 #'     pol = rep(c("blue", "swing", "swing"), each = 2)) %>% # 2 extra keys
-#'   as_epi_df(additional_metadata = list(other_keys = "state", "pol")) %>%
+#'   as_epi_df(additional_metadata = list(other_keys = "state", "pol")) 
 #' 
 #' attr(ex3,"metadata")
 as_epi_df = function(x, ...) {

--- a/R/epi_df.R
+++ b/R/epi_df.R
@@ -105,8 +105,9 @@ NULL
 #'   then the current day-time will be used.
 #' @param additional_metadata List of additional metadata to attach to the
 #'   `epi_df` object. The metadata will have `geo_type`, `time_type`, and
-#'   `as_of` fields; named entries from the passed list or will be included as
-#'   well.
+#'   `as_of` fields; named entries from the passed list will be included as
+#'   well. If your tibble has additional keys, be sure to specify them 
+#'   in the `other_keys` component of `additional_metadata`. 
 #' @param ... Additional arguments passed to methods.
 #' @return An `epi_df` object.
 #' 
@@ -188,8 +189,9 @@ new_epi_df = function(x = tibble::tibble(), geo_type, time_type, as_of,
 #'   then the current day-time will be used.
 #' @param additional_metadata List of additional metadata to attach to the
 #'   `epi_df` object. The metadata will have `geo_type`, `time_type`, and
-#'   `as_of` fields; named entries from the passed list or will be included as
-#'   well.
+#'   `as_of` fields; named entries from the passed list will be included as
+#'   well. If your tibble has additional keys, be sure to specify them 
+#'   in the `other_keys` component of `additional_metadata`.
 #' @param ... Additional arguments passed to methods.
 #' @return An `epi_df` object.
 #'
@@ -248,9 +250,12 @@ new_epi_df = function(x = tibble::tibble(), geo_type, time_type, as_of,
 #' 
 #' ex3 <- ex3_input %>% 
 #'   tsibble::as_tsibble() %>% # needed to add the additional metadata
+#'   # add 2 extra keys
 #'   dplyr::mutate(
 #'     state = rep("MA",6),
-#'     pol = rep(c("blue", "swing", "swing"), each = 2)) %>% # 2 extra keys
+#'     pol = rep(c("blue", "swing", "swing"), each = 2)) %>% 
+#'   # the 2 extra keys we added have to be specified in the other_keys 
+#'   # component of additional_metadata.
 #'   as_epi_df(additional_metadata = list(other_keys = c("state", "pol")))
 #' 
 #' attr(ex3,"metadata")

--- a/man/as_epi_archive.Rd
+++ b/man/as_epi_archive.Rd
@@ -91,15 +91,11 @@ examples.
 }
 \details{
 This simply a wrapper around the \code{new()} method of the \code{epi_archive}
-class, so for example:
+class, so for example:\preformatted{x <- as_epi_archive(df, geo_type = "state", time_type = "day")
+}
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{x <- as_epi_archive(df, geo_type = "state", time_type = "day")
-}\if{html}{\out{</div>}}
-
-would be equivalent to:
-
-\if{html}{\out{<div class="sourceCode">}}\preformatted{x <- epi_archive$new(df, geo_type = "state", time_type = "day")
-}\if{html}{\out{</div>}}
+would be equivalent to:\preformatted{x <- epi_archive$new(df, geo_type = "state", time_type = "day")
+}
 }
 \examples{
 # Simple ex. with necessary keys

--- a/man/as_epi_df.Rd
+++ b/man/as_epi_df.Rd
@@ -39,8 +39,9 @@ then the current day-time will be used.}
 
 \item{additional_metadata}{List of additional metadata to attach to the
 \code{epi_df} object. The metadata will have \code{geo_type}, \code{time_type}, and
-\code{as_of} fields; named entries from the passed list or will be included as
-well.}
+\code{as_of} fields; named entries from the passed list will be included as
+well. If your tibble has additional keys, be sure to specify them
+in the \code{other_keys} component of \code{additional_metadata}.}
 }
 \value{
 An \code{epi_df} object.
@@ -123,9 +124,12 @@ ex3_input <- jhu_csse_county_level_subset \%>\%
 
 ex3 <- ex3_input \%>\% 
   tsibble::as_tsibble() \%>\% # needed to add the additional metadata
+  # add 2 extra keys
   dplyr::mutate(
     state = rep("MA",6),
-    pol = rep(c("blue", "swing", "swing"), each = 2)) \%>\% # 2 extra keys
+    pol = rep(c("blue", "swing", "swing"), each = 2)) \%>\% 
+  # the 2 extra keys we added have to be specified in the other_keys 
+  # component of additional_metadata.
   as_epi_df(additional_metadata = list(other_keys = c("state", "pol")))
 
 attr(ex3,"metadata")

--- a/man/as_epi_df.Rd
+++ b/man/as_epi_df.Rd
@@ -126,7 +126,7 @@ ex3 <- ex3_input \%>\%
   dplyr::mutate(
     state = rep("MA",6),
     pol = rep(c("blue", "swing", "swing"), each = 2)) \%>\% # 2 extra keys
-  as_epi_df(additional_metadata = list(other_keys = "state", "pol")) 
+  as_epi_df(additional_metadata = list(other_keys = c("state", "pol")))
 
 attr(ex3,"metadata")
 }

--- a/man/as_epi_df.Rd
+++ b/man/as_epi_df.Rd
@@ -40,8 +40,8 @@ then the current day-time will be used.}
 \item{additional_metadata}{List of additional metadata to attach to the
 \code{epi_df} object. The metadata will have \code{geo_type}, \code{time_type}, and
 \code{as_of} fields; named entries from the passed list will be included as
-well. If your tibble has additional keys, be sure to specify them
-in the \code{other_keys} component of \code{additional_metadata}.}
+well. If your tibble has additional keys, be sure to specify them as a
+character vector in the \code{other_keys} component of \code{additional_metadata}.}
 }
 \value{
 An \code{epi_df} object.

--- a/man/as_epi_df.Rd
+++ b/man/as_epi_df.Rd
@@ -51,9 +51,9 @@ examples.
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{as_epi_df(epi_df)}: Simply returns the \code{epi_df} object unchanged.
+\item \code{epi_df}: Simply returns the \code{epi_df} object unchanged.
 
-\item \code{as_epi_df(tbl_df)}: The input tibble \code{x} must contain the columns
+\item \code{tbl_df}: The input tibble \code{x} must contain the columns
 \code{geo_value} and \code{time_value}. All other columns will be preserved as is,
 and treated as measured variables. If \code{as_of} is missing, then the function
 will try to guess it from an \code{as_of}, \code{issue}, or \code{version} column of \code{x}
@@ -61,14 +61,14 @@ will try to guess it from an \code{as_of}, \code{issue}, or \code{version} colum
 (stored in its attributes); if this fails, then the current day-time will
 be used.
 
-\item \code{as_epi_df(data.frame)}: Works analogously to \code{as_epi_df.tbl_df()}.
+\item \code{data.frame}: Works analogously to \code{as_epi_df.tbl_df()}.
 
-\item \code{as_epi_df(tbl_ts)}: Works analogously to \code{as_epi_df.tbl_df()}, except that
+\item \code{tbl_ts}: Works analogously to \code{as_epi_df.tbl_df()}, except that
 the \code{tbl_ts} class is dropped, and any key variables (other than
 "geo_value") are added to the metadata of the returned object, under the
 \code{other_keys} field.
-
 }}
+
 \examples{
 # Convert a `tsibble` that has county code as an extra key
 # Notice that county code should be a character string to preserve any leading zeroes
@@ -109,7 +109,7 @@ print(ex2_input)
 
 ex2 <- ex2_input \%>\% dplyr::rename(geo_value = state, time_value = reported_date) \%>\%
   as_epi_df(geo_type = "state", as_of = "2020-06-03", 
-            additional_metadata = c(other_keys = "pol"))
+            additional_metadata = list(other_keys = "pol")) 
 
 attr(ex2,"metadata")
 
@@ -123,8 +123,10 @@ ex3_input <- jhu_csse_county_level_subset \%>\%
 
 ex3 <- ex3_input \%>\% 
   tsibble::as_tsibble() \%>\% # needed to add the additional metadata
-  dplyr::mutate(state = rep("MA",6)) \%>\%
-  as_epi_df(additional_metadata = c(other_keys = "state"))
+  dplyr::mutate(
+    state = rep("MA",6),
+    pol = rep(c("blue", "swing", "swing"), each = 2)) \%>\% # 2 extra keys
+  as_epi_df(additional_metadata = list(other_keys = "state", "pol")) 
 
 attr(ex3,"metadata")
 }

--- a/man/epi_archive.Rd
+++ b/man/epi_archive.Rd
@@ -114,18 +114,18 @@ toy_epi_archive
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-epi_archive-new}{\code{epi_archive$new()}}
-\item \href{#method-epi_archive-print}{\code{epi_archive$print()}}
-\item \href{#method-epi_archive-as_of}{\code{epi_archive$as_of()}}
-\item \href{#method-epi_archive-fill_through_version}{\code{epi_archive$fill_through_version()}}
-\item \href{#method-epi_archive-merge}{\code{epi_archive$merge()}}
-\item \href{#method-epi_archive-slide}{\code{epi_archive$slide()}}
-\item \href{#method-epi_archive-clone}{\code{epi_archive$clone()}}
+\item \href{#method-new}{\code{epi_archive$new()}}
+\item \href{#method-print}{\code{epi_archive$print()}}
+\item \href{#method-as_of}{\code{epi_archive$as_of()}}
+\item \href{#method-fill_through_version}{\code{epi_archive$fill_through_version()}}
+\item \href{#method-merge}{\code{epi_archive$merge()}}
+\item \href{#method-slide}{\code{epi_archive$slide()}}
+\item \href{#method-clone}{\code{epi_archive$clone()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-epi_archive-new"></a>}}
-\if{latex}{\out{\hypertarget{method-epi_archive-new}{}}}
+\if{html}{\out{<a id="method-new"></a>}}
+\if{latex}{\out{\hypertarget{method-new}{}}}
 \subsection{Method \code{new()}}{
 Creates a new \code{epi_archive} object.
 \subsection{Usage}{
@@ -195,8 +195,8 @@ An \code{epi_archive} object.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-epi_archive-print"></a>}}
-\if{latex}{\out{\hypertarget{method-epi_archive-print}{}}}
+\if{html}{\out{<a id="method-print"></a>}}
+\if{latex}{\out{\hypertarget{method-print}{}}}
 \subsection{Method \code{print()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{epi_archive$print()}\if{html}{\out{</div>}}
@@ -204,8 +204,8 @@ An \code{epi_archive} object.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-epi_archive-as_of"></a>}}
-\if{latex}{\out{\hypertarget{method-epi_archive-as_of}{}}}
+\if{html}{\out{<a id="method-as_of"></a>}}
+\if{latex}{\out{\hypertarget{method-as_of}{}}}
 \subsection{Method \code{as_of()}}{
 Generates a snapshot in \code{epi_df} format as of a given version.
 See the documentation for the wrapper function \code{\link[=epix_as_of]{epix_as_of()}} for details.
@@ -215,8 +215,8 @@ See the documentation for the wrapper function \code{\link[=epix_as_of]{epix_as_
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-epi_archive-fill_through_version"></a>}}
-\if{latex}{\out{\hypertarget{method-epi_archive-fill_through_version}{}}}
+\if{html}{\out{<a id="method-fill_through_version"></a>}}
+\if{latex}{\out{\hypertarget{method-fill_through_version}{}}}
 \subsection{Method \code{fill_through_version()}}{
 Fill in unobserved history using requested scheme by mutating
 \code{self} and potentially reseating its fields. See
@@ -237,8 +237,8 @@ version, which doesn't mutate the input archive but might alias its fields.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-epi_archive-merge"></a>}}
-\if{latex}{\out{\hypertarget{method-epi_archive-merge}{}}}
+\if{html}{\out{<a id="method-merge"></a>}}
+\if{latex}{\out{\hypertarget{method-merge}{}}}
 \subsection{Method \code{merge()}}{
 Merges another \code{epi_archive} with the current one, mutating the
 current one by reseating its \code{DT} and several other fields, but avoiding
@@ -267,8 +267,8 @@ does not alias either archive's \code{DT}.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-epi_archive-slide"></a>}}
-\if{latex}{\out{\hypertarget{method-epi_archive-slide}{}}}
+\if{html}{\out{<a id="method-slide"></a>}}
+\if{latex}{\out{\hypertarget{method-slide}{}}}
 \subsection{Method \code{slide()}}{
 Slides a given function over variables in an \code{epi_archive}
 object. See the documentation for the wrapper function \code{\link[=epix_slide]{epix_slide()}} for
@@ -290,8 +290,8 @@ details.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-epi_archive-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-epi_archive-clone}{}}}
+\if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/epi_slide.Rd
+++ b/man/epi_slide.Rd
@@ -107,16 +107,12 @@ incomplete windows) is therefore left up to the user, either through the
 specified function or formula \code{f}, or through post-processing.
 
 If \code{f} is missing, then an expression for tidy evaluation can be specified,
-for example, as in:
+for example, as in:\preformatted{epi_slide(x, cases_7dav = mean(cases), n = 7)
+}
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{epi_slide(x, cases_7dav = mean(cases), n = 7)
-}\if{html}{\out{</div>}}
-
-which would be equivalent to:
-
-\if{html}{\out{<div class="sourceCode">}}\preformatted{epi_slide(x, function(x, ...) mean(x$cases), n = 7,
+which would be equivalent to:\preformatted{epi_slide(x, function(x, ...) mean(x$cases), n = 7,
           new_col_name = "cases_7dav")
-}\if{html}{\out{</div>}}
+}
 
 Thus, to be clear, when the computation is specified via an expression for
 tidy evaluation (first example, above), then the name for the new column is

--- a/man/epix_as_of.Rd
+++ b/man/epix_as_of.Rd
@@ -29,15 +29,11 @@ examples.
 }
 \details{
 This is simply a wrapper around the \code{as_of()} method of the
-\code{epi_archive} class, so if \code{x} is an \code{epi_archive} object, then:
+\code{epi_archive} class, so if \code{x} is an \code{epi_archive} object, then:\preformatted{epix_as_of(x, max_version = v)
+}
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{epix_as_of(x, max_version = v)
-}\if{html}{\out{</div>}}
-
-is equivalent to:
-
-\if{html}{\out{<div class="sourceCode">}}\preformatted{x$as_of(max_version = v)
-}\if{html}{\out{</div>}}
+is equivalent to:\preformatted{x$as_of(max_version = v)
+}
 }
 \examples{
 # warning message of data latency shown

--- a/man/epix_slide.Rd
+++ b/man/epix_slide.Rd
@@ -115,15 +115,11 @@ should never be used in place of \code{epi_slide()}, and only used when
 version-aware sliding is necessary (as it its purpose).
 
 Finally, this is simply a wrapper around the \code{slide()} method of the
-\code{epi_archive} class, so if \code{x} is an \code{epi_archive} object, then:
+\code{epi_archive} class, so if \code{x} is an \code{epi_archive} object, then:\preformatted{epix_slide(x, new_var = comp(old_var), n = 120)
+}
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{epix_slide(x, new_var = comp(old_var), n = 120)
-}\if{html}{\out{</div>}}
-
-is equivalent to:
-
-\if{html}{\out{<div class="sourceCode">}}\preformatted{x$slide(x, new_var = comp(old_var), n = 120)
-}\if{html}{\out{</div>}}
+is equivalent to:\preformatted{x$slide(x, new_var = comp(old_var), n = 120)
+}
 }
 \examples{
 # these dates are reference time points for the 3 day average sliding window

--- a/man/new_epi_df.Rd
+++ b/man/new_epi_df.Rd
@@ -32,8 +32,9 @@ then the current day-time will be used.}
 
 \item{additional_metadata}{List of additional metadata to attach to the
 \code{epi_df} object. The metadata will have \code{geo_type}, \code{time_type}, and
-\code{as_of} fields; named entries from the passed list or will be included as
-well.}
+\code{as_of} fields; named entries from the passed list will be included as
+well. If your tibble has additional keys, be sure to specify them
+in the \code{other_keys} component of \code{additional_metadata}.}
 
 \item{...}{Additional arguments passed to methods.}
 }

--- a/man/new_epi_df.Rd
+++ b/man/new_epi_df.Rd
@@ -33,8 +33,8 @@ then the current day-time will be used.}
 \item{additional_metadata}{List of additional metadata to attach to the
 \code{epi_df} object. The metadata will have \code{geo_type}, \code{time_type}, and
 \code{as_of} fields; named entries from the passed list will be included as
-well. If your tibble has additional keys, be sure to specify them
-in the \code{other_keys} component of \code{additional_metadata}.}
+well. If your tibble has additional keys, be sure to specify them as a
+character vector in the \code{other_keys} component of \code{additional_metadata}.}
 
 \item{...}{Additional arguments passed to methods.}
 }

--- a/tests/testthat/test-epi_df.R
+++ b/tests/testthat/test-epi_df.R
@@ -24,3 +24,18 @@ test_that("new_epi_df works as intended", {
   expect_identical(attributes(epi_tib)$metadata$time_type, "day")
   expect_true(lubridate::is.POSIXt(attributes(epi_tib)$metadata$as_of))
 })
+
+test_that("as_epi_df errors when additional_metadata is not a list", {
+  # This is the 3rd example from as_epi_df
+  ex_input <- jhu_csse_county_level_subset %>%
+    dplyr::filter(time_value > "2021-12-01", state_name == "Massachusetts") %>%
+    dplyr::slice_tail(n = 6) %>%
+    tsibble::as_tsibble() %>%
+    dplyr::mutate(
+      state = rep("MA",6),
+      pol = rep(c("blue", "swing", "swing"), each = 2))
+  
+  expect_error(
+    as_epi_df(ex_input, additional_metadata = c(other_keys = "state", "pol")), 
+    "`additional_metadata` must be a list type.")
+})

--- a/tests/testthat/test-methods-epi_df.R
+++ b/tests/testthat/test-methods-epi_df.R
@@ -8,7 +8,7 @@ toy_epi_df <- tibble::tibble(
   ), times = 2),
   geo_value = rep(c("ca", "hi"), each = 5),
   indicator_var = as.factor(rep(1:2, times = 5)), 
-) %>% as_epi_df(additional_metadata = c(other_keys = "indicator_var"))
+) %>% as_epi_df(additional_metadata = list(other_keys = "indicator_var"))
 
 att_toy = attr(toy_epi_df, "metadata")
 

--- a/vignettes/epiprocess.Rmd
+++ b/vignettes/epiprocess.Rmd
@@ -180,7 +180,7 @@ head(ex2)
 
 ex2 <- ex2 %>% rename(geo_value = state, time_value = reported_date) %>%
   as_epi_df(geo_type = "state", as_of = "2020-06-03", 
-            additional_metadata = c(other_keys = "pol"))
+            additional_metadata = list(other_keys = "pol"))
 
 attr(ex2,"metadata")
 ```
@@ -206,7 +206,7 @@ Now we add state (MA) as a new column and a key to the metadata. Reminder that l
 ex3 <- ex3 %>% 
   as_tibble() %>% # needed to add the additional metadata
   mutate(state = rep(tolower("MA"),6)) %>%
-  as_epi_df(additional_metadata = c(other_keys = "state"))
+  as_epi_df(additional_metadata = list(other_keys = "state"))
 
 attr(ex3,"metadata")
 ```

--- a/vignettes/epiprocess.Rmd
+++ b/vignettes/epiprocess.Rmd
@@ -200,16 +200,20 @@ ex3 <- jhu_csse_county_level_subset %>%
 attr(ex3,"metadata") # geo_type is county currently
 ```
 
-Now we add state (MA) as a new column and a key to the metadata. Reminder that lower case state name abbreviations are what we would expect if this were a `geo_value` column.
-```{r}
+Now we add `state` (MA) and `pol` as new columns to the data and as new keys to the metadata. Reminder that lower case state name abbreviations are what we would expect if this were a `geo_value` column. 
 
+```{r}
 ex3 <- ex3 %>% 
   as_tibble() %>% # needed to add the additional metadata
-  mutate(state = rep(tolower("MA"),6)) %>%
-  as_epi_df(additional_metadata = list(other_keys = "state"))
+  mutate(
+    state = rep(tolower("MA"),6),
+    pol = rep(c("blue", "swing", "swing"), each = 2)) %>%
+  as_epi_df(additional_metadata = list(other_keys = c("state", "pol")))
 
 attr(ex3,"metadata")
 ```
+
+Note that the two additional keys we added, `state` and `pol`, are specified as a character vector in the `other_keys` component of the `additional_metadata` list. They must be specified in this manner so that downstream actions on the `epi_df`, like model fitting and prediction, can recognize and use these keys.
 
 Currently `other_keys` metadata in `epi_df` doesn't impact `epi_slide()`, contrary to `other_keys` in `as_epi_archive` which affects how the update data is interpreted.
 


### PR DESCRIPTION
Addresses #182 

Changes:
- Update `new_epi_df` examples so that (i) `additional_metadata` argument is type `list` instead of `vector` and (ii) there is an example with multiple `other_keys`
- Add a check in `new_epi_df` to ensure `additional_metadata` is a `list`
- Write a test for the previous change

I checked in `epipredict` for calls to `as_epi_df` and all `additional_metadata` arguments there are `lists` so this change will not break `epipredict`. Afaik there aren't any dependencies on `epiprocess` other than `epipredict`.