### PR TITLE
Improve description of `all_rows` setting, and error for invalid `group_by` selection

### DIFF
--- a/R/archive.R
+++ b/R/archive.R
@@ -723,7 +723,8 @@ epi_archive =
             # Join to get all rows, if we need to, then return
             if (all_rows) {
               cols = c(as.character(group_by), "time_value")
-              y = unique(self$DT[, ..cols])
+              y = unique(self$DT[, ..cols]) %>%
+                  tibble::as_tibble()
               x = dplyr::left_join(y, x, by = cols)
             }
             return(x)

--- a/R/methods-epi_archive.R
+++ b/R/methods-epi_archive.R
@@ -417,7 +417,7 @@ epix_merge = function(x, y,
 #'   method), and (2) it performs a "manual" sliding of sorts, and does not
 #'   benefit from the highly efficient `slider` package. For this reason, it
 #'   should never be used in place of `epi_slide()`, and only used when
-#'   version-aware sliding is necessary (as it its purpose).
+#'   version-aware sliding is necessary (as is its purpose).
 #'
 #' Finally, this is simply a wrapper around the `slide()` method of the
 #'   `epi_archive` class, so if `x` is an `epi_archive` object, then:
@@ -437,7 +437,7 @@ epix_merge = function(x, y,
 #' # 0 day which has no results, for 2020-06-01
 #' # 1 day, for 2020-06-02
 #' # 2 days, for the rest of the results
-#' # never 3 days dur to data latency
+#' # never 3 days due to data latency
 #' 
 #' time_values <- seq(as.Date("2020-06-01"),
 #'                       as.Date("2020-06-15"),

--- a/man/epix_slide.Rd
+++ b/man/epix_slide.Rd
@@ -112,7 +112,7 @@ properly-versioned snapshots from the data archive (via its \code{as_of()}
 method), and (2) it performs a "manual" sliding of sorts, and does not
 benefit from the highly efficient \code{slider} package. For this reason, it
 should never be used in place of \code{epi_slide()}, and only used when
-version-aware sliding is necessary (as it its purpose).
+version-aware sliding is necessary (as is its purpose).
 
 Finally, this is simply a wrapper around the \code{slide()} method of the
 \code{epi_archive} class, so if \code{x} is an \code{epi_archive} object, then:
@@ -131,7 +131,7 @@ is equivalent to:
 # 0 day which has no results, for 2020-06-01
 # 1 day, for 2020-06-02
 # 2 days, for the rest of the results
-# never 3 days dur to data latency
+# never 3 days due to data latency
 
 time_values <- seq(as.Date("2020-06-01"),
                       as.Date("2020-06-15"),


### PR DESCRIPTION
### Description
Make description of `all_rows` behavior clearer. Make desired behavior explicit by raising error if `version` or `time_value` is set by the user in `group_by`. Make output a tibble when `all_rows` is toggled on to conform to documentation.

### Changes
- `archive.R`
- `.Rd` files

### Fixes
Closes https://github.com/cmu-delphi/epiprocess/issues/147.