### PR TITLE
Use renamed `delphi.epidata` pkg `epidatr` (& its new repo name)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Imports:
     vctrs
 Suggests:
     covidcast,
-    delphi.epidata,
+    epidatr,
     ggplot2,
     knitr,
     outbreaks,
@@ -52,7 +52,7 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    dajmcdon/delphi.epidata,
+    cmu-delphi/epidatr,
     reconverse/outbreaks
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/data-raw/archive_cases_dv_subset.R
+++ b/data-raw/archive_cases_dv_subset.R
@@ -1,4 +1,4 @@
-library(delphi.epidata)
+library(epidatr)
 library(epiprocess)
 library(data.table)
 library(dplyr)

--- a/data-raw/incidence_num_outlier_example.R
+++ b/data-raw/incidence_num_outlier_example.R
@@ -1,4 +1,4 @@
-library(delphi.epidata)
+library(epidatr)
 library(epiprocess)
 library(dplyr)
 library(tidyr)

--- a/data-raw/jhu_csse_county_level_subset.R
+++ b/data-raw/jhu_csse_county_level_subset.R
@@ -1,4 +1,4 @@
-library(delphi.epidata)
+library(epidatr)
 library(covidcast)
 library(epiprocess)
 library(dplyr)

--- a/data-raw/jhu_csse_daily_subset.R
+++ b/data-raw/jhu_csse_daily_subset.R
@@ -1,4 +1,4 @@
-library(delphi.epidata)
+library(epidatr)
 library(epiprocess)
 library(dplyr)
 

--- a/vignettes/advanced.Rmd
+++ b/vignettes/advanced.Rmd
@@ -192,7 +192,7 @@ to demonstrate the last point in a more realistic setting. First, we fetch the
 versioned data and build the archive.
 
 ```{r, message = FALSE, warning = FALSE, eval =FALSE}
-library(delphi.epidata)
+library(epidatr)
 library(data.table)
 library(ggplot2)
 theme_set(theme_bw())

--- a/vignettes/aggregation.Rmd
+++ b/vignettes/aggregation.Rmd
@@ -13,7 +13,7 @@ kinds of tasks with `epi_df` objects. We'll work with county-level reported
 COVID-19 cases in MA and VT.
 
 ```{r, message = FALSE, eval= FALSE, warning= FALSE}
-library(delphi.epidata)
+library(epidatr)
 library(covidcast)
 library(epiprocess)
 library(dplyr)
@@ -41,7 +41,7 @@ x <- covidcast(
 The data contains 16,212 rows and 5 columns.
 
 ```{r, echo=FALSE, warning=FALSE, message=FALSE}
-library(delphi.epidata)
+library(epidatr)
 library(covidcast)
 library(epiprocess)
 library(dplyr)

--- a/vignettes/archive.Rmd
+++ b/vignettes/archive.Rmd
@@ -26,7 +26,7 @@ on its [API documentation
 page](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/doctor-visits.html).
 
 ```{r, message = FALSE, warning = FALSE, eval=FALSE}
-library(delphi.epidata)
+library(epidatr)
 library(epiprocess)
 library(data.table)
 library(dplyr)
@@ -44,7 +44,7 @@ dv <- covidcast(
 ```
 
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
-library(delphi.epidata)
+library(epidatr)
 library(epiprocess)
 library(data.table)
 library(dplyr)
@@ -64,7 +64,7 @@ has (at least) the following columns:
   the data for January 14, 2022 that were available one day later.
 
 As we can see from the above, the data frame returned by
-`delphi.epidata::covidcast()` has the columns required for the `epi_archive`
+`epidatr::covidcast()` has the columns required for the `epi_archive`
 format, with `issue` playing the role of `version`. We can now use
 `as_epi_archive()` to bring it into `epi_archive` format. For removal of
 redundant version updates in `as_epi_archive` using compactify, please refer

--- a/vignettes/correlation.Rmd
+++ b/vignettes/correlation.Rmd
@@ -16,7 +16,7 @@ state-level COVID-19 case and death rates, smoothed using 7-day trailing
 averages.
 
 ```{r, message = FALSE, warning = FALSE}
-library(delphi.epidata)
+library(epidatr)
 library(epiprocess)
 library(dplyr)
 ```

--- a/vignettes/epiprocess.Rmd
+++ b/vignettes/epiprocess.Rmd
@@ -50,12 +50,12 @@ A data frame or tibble that has `geo_value` and `time_value` columns can be
 converted into an `epi_df` object, using the function `as_epi_df()`. As an
 example, we'll work with daily cumulative COVID-19 cases from four U.S. states:
 CA, FL, NY, and TX, over time span from mid 2020 to early 2022, and we'll use
-the [`delphi.epidata`](https://github.com/cmu-delphi/delphi-epidata-r) package
+the [`epidatr`](https://github.com/cmu-delphi/epidatr) package
 to fetch this data from the [COVIDcast
 API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast.html).
 
 ```{r, message = FALSE}
-library(delphi.epidata)
+library(epidatr)
 library(epiprocess)
 library(dplyr)
 library(withr)
@@ -72,7 +72,7 @@ cases <- covidcast(
 colnames(cases)
 ```
 
-As we can see, a data frame returned by `delphi.epidata::covidcast()` has the
+As we can see, a data frame returned by `epidatr::covidcast()` has the
 columns required for an `epi_df` object (along with many others). We can use
 `as_epi_df()`, with specification of some relevant metadata, to bring the data
 frame into `epi_df` format.

--- a/vignettes/growth_rate.Rmd
+++ b/vignettes/growth_rate.Rmd
@@ -15,7 +15,7 @@ current vignette, applied to state-level daily reported COVID-19 cases from GA
 and PA, smoothed using a 7-day trailing average.
 
 ```{r, message = FALSE, warning = FALSE}
-library(delphi.epidata)
+library(epidatr)
 library(epiprocess)
 library(dplyr)
 library(tidyr)

--- a/vignettes/outliers.Rmd
+++ b/vignettes/outliers.Rmd
@@ -15,7 +15,7 @@ apply them to `epi_df` objects. We'll demonstrate this using state-level daily
 reported COVID-19 case counts from FL and NJ.
 
 ```{r, message = FALSE, eval= FALSE}
-library(delphi.epidata)
+library(epidatr)
 library(epiprocess)
 library(dplyr)
 library(tidyr)
@@ -37,7 +37,7 @@ x <- covidcast(
 The dataset has 730 rows and 3 columns.
 
 ```{r, echo=FALSE, warning=FALSE, message=FALSE}
-library(delphi.epidata)
+library(epidatr)
 library(epiprocess)
 library(dplyr)
 library(tidyr)

--- a/vignettes/slide.Rmd
+++ b/vignettes/slide.Rmd
@@ -26,11 +26,11 @@ in this vignette.
 
 As in getting started guide, we'll fetch daily reported COVID-19 cases from CA,
 FL, NY, and TX (note: here we're using new, not cumulative cases) using the
-[`delphi.epidata`](https://github.com/cmu-delphi/delphi-epidata-r) package,
+[`epidatr`](https://github.com/cmu-delphi/epidatr) package,
 and then convert this to `epi_df` format.
 
 ```{r, message = FALSE, warning=FALSE}
-library(delphi.epidata)
+library(epidatr)
 library(epiprocess)
 library(dplyr)
 ```


### PR DESCRIPTION
This should address the issues noted [here](https://github.com/cmu-delphi/epidatr/issues/31), allowing us to point to the main repo (in `cmu-delphi/` org) for the new delphi-epidata R client package without upsetting `devtools`, `pak`, `renv`, or CI.  To be merged after https://github.com/cmu-delphi/epidatr/pull/39.