### PR TITLE
Removed as_tibble() calls in archive slide fun

### DIFF
--- a/R/archive.R
+++ b/R/archive.R
@@ -675,7 +675,6 @@ epi_archive =
               
               x = purrr::map_dfr(ref_time_values, function(t) {
                 self$as_of(t, min_time_value = t - before_num) %>%
-                  tibble::as_tibble() %>% 
                   dplyr::group_by(!!!group_by) %>%
                   dplyr::group_modify(comp_one_grp,
                                       f = f, ..., 
@@ -703,7 +702,6 @@ epi_archive =
 
               x = purrr::map_dfr(ref_time_values, function(t) {
                 self$as_of(t, min_time_value = t - before_num) %>%
-                  tibble::as_tibble() %>% 
                   dplyr::group_by(!!!group_by) %>%
                   dplyr::group_modify(comp_one_grp,
                                       f = f, quo = quo,

--- a/man/as_epi_archive.Rd
+++ b/man/as_epi_archive.Rd
@@ -91,11 +91,15 @@ examples.
 }
 \details{
 This simply a wrapper around the \code{new()} method of the \code{epi_archive}
-class, so for example:\preformatted{x <- as_epi_archive(df, geo_type = "state", time_type = "day")
-}
+class, so for example:
 
-would be equivalent to:\preformatted{x <- epi_archive$new(df, geo_type = "state", time_type = "day")
-}
+\if{html}{\out{<div class="sourceCode">}}\preformatted{x <- as_epi_archive(df, geo_type = "state", time_type = "day")
+}\if{html}{\out{</div>}}
+
+would be equivalent to:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{x <- epi_archive$new(df, geo_type = "state", time_type = "day")
+}\if{html}{\out{</div>}}
 }
 \examples{
 # Simple ex. with necessary keys

--- a/man/as_epi_df.Rd
+++ b/man/as_epi_df.Rd
@@ -52,9 +52,9 @@ examples.
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{epi_df}: Simply returns the \code{epi_df} object unchanged.
+\item \code{as_epi_df(epi_df)}: Simply returns the \code{epi_df} object unchanged.
 
-\item \code{tbl_df}: The input tibble \code{x} must contain the columns
+\item \code{as_epi_df(tbl_df)}: The input tibble \code{x} must contain the columns
 \code{geo_value} and \code{time_value}. All other columns will be preserved as is,
 and treated as measured variables. If \code{as_of} is missing, then the function
 will try to guess it from an \code{as_of}, \code{issue}, or \code{version} column of \code{x}
@@ -62,14 +62,14 @@ will try to guess it from an \code{as_of}, \code{issue}, or \code{version} colum
 (stored in its attributes); if this fails, then the current day-time will
 be used.
 
-\item \code{data.frame}: Works analogously to \code{as_epi_df.tbl_df()}.
+\item \code{as_epi_df(data.frame)}: Works analogously to \code{as_epi_df.tbl_df()}.
 
-\item \code{tbl_ts}: Works analogously to \code{as_epi_df.tbl_df()}, except that
+\item \code{as_epi_df(tbl_ts)}: Works analogously to \code{as_epi_df.tbl_df()}, except that
 the \code{tbl_ts} class is dropped, and any key variables (other than
 "geo_value") are added to the metadata of the returned object, under the
 \code{other_keys} field.
-}}
 
+}}
 \examples{
 # Convert a `tsibble` that has county code as an extra key
 # Notice that county code should be a character string to preserve any leading zeroes

--- a/man/epi_archive.Rd
+++ b/man/epi_archive.Rd
@@ -114,18 +114,18 @@ toy_epi_archive
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{epi_archive$new()}}
-\item \href{#method-print}{\code{epi_archive$print()}}
-\item \href{#method-as_of}{\code{epi_archive$as_of()}}
-\item \href{#method-fill_through_version}{\code{epi_archive$fill_through_version()}}
-\item \href{#method-merge}{\code{epi_archive$merge()}}
-\item \href{#method-slide}{\code{epi_archive$slide()}}
-\item \href{#method-clone}{\code{epi_archive$clone()}}
+\item \href{#method-epi_archive-new}{\code{epi_archive$new()}}
+\item \href{#method-epi_archive-print}{\code{epi_archive$print()}}
+\item \href{#method-epi_archive-as_of}{\code{epi_archive$as_of()}}
+\item \href{#method-epi_archive-fill_through_version}{\code{epi_archive$fill_through_version()}}
+\item \href{#method-epi_archive-merge}{\code{epi_archive$merge()}}
+\item \href{#method-epi_archive-slide}{\code{epi_archive$slide()}}
+\item \href{#method-epi_archive-clone}{\code{epi_archive$clone()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-epi_archive-new"></a>}}
+\if{latex}{\out{\hypertarget{method-epi_archive-new}{}}}
 \subsection{Method \code{new()}}{
 Creates a new \code{epi_archive} object.
 \subsection{Usage}{
@@ -195,8 +195,8 @@ An \code{epi_archive} object.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-print"></a>}}
-\if{latex}{\out{\hypertarget{method-print}{}}}
+\if{html}{\out{<a id="method-epi_archive-print"></a>}}
+\if{latex}{\out{\hypertarget{method-epi_archive-print}{}}}
 \subsection{Method \code{print()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{epi_archive$print()}\if{html}{\out{</div>}}
@@ -204,8 +204,8 @@ An \code{epi_archive} object.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-as_of"></a>}}
-\if{latex}{\out{\hypertarget{method-as_of}{}}}
+\if{html}{\out{<a id="method-epi_archive-as_of"></a>}}
+\if{latex}{\out{\hypertarget{method-epi_archive-as_of}{}}}
 \subsection{Method \code{as_of()}}{
 Generates a snapshot in \code{epi_df} format as of a given version.
 See the documentation for the wrapper function \code{\link[=epix_as_of]{epix_as_of()}} for details.
@@ -215,8 +215,8 @@ See the documentation for the wrapper function \code{\link[=epix_as_of]{epix_as_
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-fill_through_version"></a>}}
-\if{latex}{\out{\hypertarget{method-fill_through_version}{}}}
+\if{html}{\out{<a id="method-epi_archive-fill_through_version"></a>}}
+\if{latex}{\out{\hypertarget{method-epi_archive-fill_through_version}{}}}
 \subsection{Method \code{fill_through_version()}}{
 Fill in unobserved history using requested scheme by mutating
 \code{self} and potentially reseating its fields. See
@@ -237,8 +237,8 @@ version, which doesn't mutate the input archive but might alias its fields.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-merge"></a>}}
-\if{latex}{\out{\hypertarget{method-merge}{}}}
+\if{html}{\out{<a id="method-epi_archive-merge"></a>}}
+\if{latex}{\out{\hypertarget{method-epi_archive-merge}{}}}
 \subsection{Method \code{merge()}}{
 Merges another \code{epi_archive} with the current one, mutating the
 current one by reseating its \code{DT} and several other fields, but avoiding
@@ -267,8 +267,8 @@ does not alias either archive's \code{DT}.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-slide"></a>}}
-\if{latex}{\out{\hypertarget{method-slide}{}}}
+\if{html}{\out{<a id="method-epi_archive-slide"></a>}}
+\if{latex}{\out{\hypertarget{method-epi_archive-slide}{}}}
 \subsection{Method \code{slide()}}{
 Slides a given function over variables in an \code{epi_archive}
 object. See the documentation for the wrapper function \code{\link[=epix_slide]{epix_slide()}} for
@@ -290,8 +290,8 @@ details.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-epi_archive-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-epi_archive-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/epi_slide.Rd
+++ b/man/epi_slide.Rd
@@ -107,12 +107,16 @@ incomplete windows) is therefore left up to the user, either through the
 specified function or formula \code{f}, or through post-processing.
 
 If \code{f} is missing, then an expression for tidy evaluation can be specified,
-for example, as in:\preformatted{epi_slide(x, cases_7dav = mean(cases), n = 7)
-}
+for example, as in:
 
-which would be equivalent to:\preformatted{epi_slide(x, function(x, ...) mean(x$cases), n = 7,
+\if{html}{\out{<div class="sourceCode">}}\preformatted{epi_slide(x, cases_7dav = mean(cases), n = 7)
+}\if{html}{\out{</div>}}
+
+which would be equivalent to:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{epi_slide(x, function(x, ...) mean(x$cases), n = 7,
           new_col_name = "cases_7dav")
-}
+}\if{html}{\out{</div>}}
 
 Thus, to be clear, when the computation is specified via an expression for
 tidy evaluation (first example, above), then the name for the new column is

--- a/man/epix_as_of.Rd
+++ b/man/epix_as_of.Rd
@@ -29,11 +29,15 @@ examples.
 }
 \details{
 This is simply a wrapper around the \code{as_of()} method of the
-\code{epi_archive} class, so if \code{x} is an \code{epi_archive} object, then:\preformatted{epix_as_of(x, max_version = v)
-}
+\code{epi_archive} class, so if \code{x} is an \code{epi_archive} object, then:
 
-is equivalent to:\preformatted{x$as_of(max_version = v)
-}
+\if{html}{\out{<div class="sourceCode">}}\preformatted{epix_as_of(x, max_version = v)
+}\if{html}{\out{</div>}}
+
+is equivalent to:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{x$as_of(max_version = v)
+}\if{html}{\out{</div>}}
 }
 \examples{
 # warning message of data latency shown

--- a/man/epix_slide.Rd
+++ b/man/epix_slide.Rd
@@ -115,11 +115,15 @@ should never be used in place of \code{epi_slide()}, and only used when
 version-aware sliding is necessary (as it its purpose).
 
 Finally, this is simply a wrapper around the \code{slide()} method of the
-\code{epi_archive} class, so if \code{x} is an \code{epi_archive} object, then:\preformatted{epix_slide(x, new_var = comp(old_var), n = 120)
-}
+\code{epi_archive} class, so if \code{x} is an \code{epi_archive} object, then:
 
-is equivalent to:\preformatted{x$slide(x, new_var = comp(old_var), n = 120)
-}
+\if{html}{\out{<div class="sourceCode">}}\preformatted{epix_slide(x, new_var = comp(old_var), n = 120)
+}\if{html}{\out{</div>}}
+
+is equivalent to:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{x$slide(x, new_var = comp(old_var), n = 120)
+}\if{html}{\out{</div>}}
 }
 \examples{
 # these dates are reference time points for the 3 day average sliding window


### PR DESCRIPTION
To resolve Issue #208 removed the two `as_tibble()` calls in archive slide function so that `epix_slide()` is compatible with `arx_forecaster()` from epipredict (to be able to slide an ARX forecaster over an archive). Making a separate issue to deal with the metadata.