### PR TITLE
Fix `epix_merge` `sync="truncate"` err (`with=F` no `j`), add tests

### DIFF
--- a/R/methods-epi_archive.R
+++ b/R/methods-epi_archive.R
@@ -152,7 +152,7 @@ epix_fill_through_version = function(x, fill_versions_end,
 #' # vs. mutating x to hold the merge result:
 #' x$merge(y)
 #'
-#' @importFrom data.table key set
+#' @importFrom data.table key set setkeyv
 #' @export
 epix_merge = function(x, y,
                       sync = c("forbid","na","locf","truncate"),
@@ -215,18 +215,34 @@ epix_merge = function(x, y,
     y_DT = epix_fill_through_version(y, new_versions_end, sync)$DT
   } else if (sync == "truncate") {
     new_versions_end = min(x$versions_end, y$versions_end)
-    x_DT = x$DT[x[["DT"]][["version"]] <= new_versions_end, with=FALSE]
-    y_DT = y$DT[y[["DT"]][["version"]] <= new_versions_end, with=FALSE]
+    x_DT = x$DT[x[["DT"]][["version"]] <= new_versions_end, names(x$DT), with=FALSE]
+    y_DT = y$DT[y[["DT"]][["version"]] <= new_versions_end, names(y$DT), with=FALSE]
   } else Abort("unimplemented")
 
   if (!identical(key(x$DT), key(x_DT)) || !identical(key(y$DT), key(y_DT))) {
     Abort("preprocessing of data tables in merge changed the key unexpectedly",
           internal=TRUE)
   }
-  ## key(x_DT) should be the same as key(x$DT) and key(y_DT) should be the same
-  ## as key(y$DT). If we want to break this function into parts it makes sense
-  ## to use {x,y}_DT below, but this makes the error checks and messages look a
-  ## little weird and rely on the key-matching assumption above.
+  # key(x_DT) should be the same as key(x$DT) and key(y_DT) should be the same
+  # as key(y$DT). If we want to break this function into parts it makes sense
+  # to use {x,y}_DT below, but this makes the error checks and messages look a
+  # little weird and rely on the key-matching assumption above.
+  #
+  # Just go ahead and test the above assumption in case different versions of
+  # data.table or certain inputs cause different behavior:
+  x_DT_key_as_expected = identical(key(x$DT), key(x_DT))
+  y_DT_key_as_expected = identical(key(y$DT), key(y_DT))
+  if (!x_DT_key_as_expected || !y_DT_key_as_expected) {
+    Warn("
+      `epiprocess` internal warning (please report): pre-processing for
+      epix_merge unexpectedly resulted in an intermediate data table (or
+      tables) with a different key than the corresponding input archive.
+      Manually setting intermediate data table keys to the expected values.
+    ", internal=TRUE)
+    setkeyv(x_DT, key(x$DT))
+    setkeyv(y_DT, key(y$DT))
+  }
+
   if (!identical(sort(key(x_DT)), sort(key(y_DT)))) {
     Abort("
             The archives must have the same set of key column names; if the


### PR DESCRIPTION
Also:
- Add an internal warning + recovery if our DT preprocessing unexpectedly
  produces a DT with a different key (although in a way that won't catch if we
  accidentally mutated the original DT's key and matched it in the intermediate
  DT). If this is triggered, we will likely need to rethink/bugfix some other DT
  usage in other code which may have made similar assumptions about certain DT
  operations not dropping/modifying the key.
- Edit the input to one set of epix_merge tests to make the truncate test more
  restrictive than it would have been otherwise, and edit a non-truncate test with
  an `expected` value that changes as a result.
  
Closes #200.