### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,4 +1,4 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
@@ -15,12 +15,12 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-      
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,7 +1,9 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
+    branches: [main, master]
+  pull_request:
     branches: [main, master]
   release:
     types: [published]
@@ -12,24 +14,33 @@ name: pkgdown
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: pkgdown
+          extra-packages: any::pkgdown, local::.
           needs: website
 
-      - name: Deploy package
-        run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: epiprocess
 Title: Tools for basic signal processing in epidemiology
-Version: 0.5.0.9999
+Version: 0.6.0
 Authors@R: c(
     person("Jacob", "Bien", role = "ctb"),
     person("Logan", "Brooks", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
-# epiprocess 0.5.0.9999 (development version)
+# epiprocess 0.6.0
 
 Note that `epiprocess` uses the [Semantic Versioning
-("semver")](https://semver.org/) scheme for all release versions, but not for
-development versions. A ".9999" suffix indicates a development version.
+("semver")](https://semver.org/) scheme for all release versions, but any
+inter-release development versions will include an additional ".9999" suffix.
 
 ## Breaking changes:
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,10 @@
-# epiprocess 0.6.0
+# epiprocess 0.6.0.9999
 
 Note that `epiprocess` uses the [Semantic Versioning
 ("semver")](https://semver.org/) scheme for all release versions, but any
 inter-release development versions will include an additional ".9999" suffix.
+
+# epiprocess 0.6.0
 
 ## Breaking changes:
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -81,6 +81,7 @@ development versions. A ".9999" suffix indicates a development version.
 * Added a `NEWS.md` file to track changes to the package.
 * Implemented `?dplyr::dplyr_extending` for `epi_df`s
   ([#223](https://github.com/cmu-delphi/epiprocess/issues/223)).
+* Fixed various small documentation issues ([#217](https://github.com/cmu-delphi/epiprocess/issues/217)).
 
 # epiprocess 0.5.0:
 
@@ -93,13 +94,13 @@ development versions. A ".9999" suffix indicates a development version.
 
 ## Improvements:
 
-* Fixed `epix_merge`, `<epi_archive>$merge` always raising error on `sync="truncate"`
+* Fixed `epix_merge`, `<epi_archive>$merge` always raising error on `sync="truncate"`.
 
 ## Cleanup:
 
-* Added `Remotes:` entry for `genlasso`, which was removed from CRAN
-* Added `as_epi_archive` tests
-* Added missing `epix_merge` test for `sync="truncate"`
+* Added `Remotes:` entry for `genlasso`, which was removed from CRAN.
+* Added `as_epi_archive` tests.
+* Added missing `epix_merge` test for `sync="truncate"`.
 
 # epiprocess 0.4.0:
 
@@ -142,7 +143,7 @@ development versions. A ".9999" suffix indicates a development version.
   * `epix_<method>` will not mutate input `epi_archive`s, but may alias them
     or alias their fields (which should not be a worry if a user sticks to
     these `epix_*` functions and "regular" R functions with
-    copy-on-write-like behavior, avoiding mutating functions `[.data.table`)
+    copy-on-write-like behavior, avoiding mutating functions `[.data.table`).
   * `x$<method>` may mutate `x`; if it mutates `x`, it will return `x`
     invisibly (where this makes sense), and, for each of its fields, may
     either mutate the object to which it refers or reseat the reference (but
@@ -183,7 +184,7 @@ development versions. A ".9999" suffix indicates a development version.
 * New function `epix_fill_through_version`, method
   `<epi_archive>$fill_through_version`: non-mutating & mutating way to
   ensure that an archive contains versions at least through some
-  `fill_versions_end`, extrapolating according to `how` if necessary
+  `fill_versions_end`, extrapolating according to `how` if necessary.
 * Example archive data object is now constructed on demand from its
   underlying data, so it will be based on the user's version of
   `epi_archive` rather than an outdated R6 implementation from whenever the
@@ -289,7 +290,7 @@ Classes:
   * `epi_cor` calculates Pearson, Kendall, or Spearman correlations
     between two (optionally time-shifted) variables in an `epi_df` within
     user-specified groups.
-  * Convenience function: `is_epi_df`
+  * Convenience function: `is_epi_df`.
 * `epi_archive`: R6 class for version (patch) data for geotemporal
   epidemiological time series data sets. Comes with S3 methods and regular
   functions that wrap around this functionality for those unfamiliar with R6
@@ -298,7 +299,7 @@ Classes:
     containing snapshots and/or patch data for every available version of
     the data set.
   * `as_of`: extracts a snapshot of the data set as of some requested
-    version, in `epi_df` format
+    version, in `epi_df` format.
   * `epix_slide`, `<epi_archive>$slide`: similar to `epi_slide`, but for
     `epi_archive`s; for each requested `ref_time_value` and group, applies
     a time window and user-specified computation to a snapshot of the data
@@ -306,7 +307,7 @@ Classes:
   * `epix_merge`, `<epi_archive>$merge`: like `merge` for `epi_archive`s,
     but allowing for the last version of each observation to be carried
     forward to fill in gaps in `x` or `y`.
-  * Convenience function: `is_epi_archive`
+  * Convenience function: `is_epi_archive`.
 
 Additional functions:
 * `growth_rate`: estimates growth rate of a time series using one of a few
@@ -314,7 +315,7 @@ Additional functions:
   smoothing splines, or trend filtering.
 * `detect_outlr`: applies one or more outlier detection methods to a given
   signal variable, and optionally aggregates the outputs to create a
-  consensus result
+  consensus result.
 * `detect_outlr_rm`: outlier detection function based on a
   rolling-median-based outlier detection function; one of the methods
   included in `detect_outlr`.

--- a/R/methods-epi_archive.R
+++ b/R/methods-epi_archive.R
@@ -82,7 +82,7 @@ epix_as_of = function(x, max_version, min_time_value = -Inf, all_versions = FALS
 #'  `x`), and returns the updated `x` [invisibly][base::invisible].
 #'
 #' @param x An `epi_archive`
-#' @param fill_versions_end Length-1, same class&type as `%s$version`: the
+#' @param fill_versions_end Length-1, same class&type as `x$version`: the
 #'   version through which to fill in missing version history; this will be the
 #'   result's `$versions_end` unless it already had a later
 #'   `$versions_end`.
@@ -699,9 +699,10 @@ group_by.epi_archive = function(.data, ..., .add=FALSE, .drop=dplyr::group_by_dr
 #' @param new_col_name String indicating the name of the new column that will
 #'   contain the derivative values. Default is "slide_value"; note that setting
 #'   `new_col_name` equal to an existing column name will overwrite this column.
-#' @param as_list_col Should the new column be stored as a list column? Default
-#'   is `FALSE`, in which case a list object returned by `f` would be unnested
-#'   (using `tidyr::unnest()`), and the names of the resulting columns are given
+#' @param as_list_col If the computations return data frames, should the slide
+#'   result hold these in a single list column or try to unnest them? Default is
+#'   `FALSE`, in which case a list object returned by `f` would be unnested
+#'   (using [`tidyr::unnest()`]), and the names of the resulting columns are given
 #'   by prepending `new_col_name` to the names of the list elements.
 #' @param names_sep String specifying the separator to use in `tidyr::unnest()`
 #'   when `as_list_col = FALSE`. Default is "_". Using `NULL` drops the prefix

--- a/R/slide.R
+++ b/R/slide.R
@@ -52,9 +52,10 @@
 #' @param new_col_name String indicating the name of the new column that will
 #'   contain the derivative values. Default is "slide_value"; note that setting
 #'   `new_col_name` equal to an existing column name will overwrite this column.
-#' @param as_list_col Should the new column be stored as a list column? Default
-#'   is `FALSE`, in which case a list object returned by `f` would be unnested
-#'   (using `tidyr::unnest()`), and the names of the resulting columns are given
+#' @param as_list_col If the computations return data frames, should the slide
+#'   result hold these in a single list column or try to unnest them? Default is
+#'   `FALSE`, in which case a list object returned by `f` would be unnested
+#'   (using [`tidyr::unnest()`]), and the names of the resulting columns are given
 #'   by prepending `new_col_name` to the names of the list elements.
 #' @param names_sep String specifying the separator to use in `tidyr::unnest()`
 #'   when `as_list_col = FALSE`. Default is "_". Using `NULL` drops the prefix

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # epiprocess
  
  <!-- badges: start -->
-  [![R-CMD-check](https://github.com/cmu-delphi/epiprocess/workflows/R-CMD-check/badge.svg)](https://github.com/cmu-delphi/epiprocess/actions)
+  [![R-CMD-check](https://github.com/cmu-delphi/epiprocess/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/cmu-delphi/epiprocess/actions/workflows/R-CMD-check.yaml)
   <!-- badges: end -->
 
 This package introduces a common data structure for epidemiological data sets
@@ -45,10 +45,10 @@ The second main data structure in the package is called
 wrapped around a data table that stores the archive (version history) of some
 signal variables of interest.
 
-By convention, functions in the `epiprocess` package that operate on `epi_df`
-objects begin with `epix` (the "x" is meant to remind you of "archive"). These
-are just wrapper functions around the public methods for the `epi_archive` R6
-class. For example:
+By convention, functions in the `epiprocess` package that operate on
+`epi_archive` objects begin with `epix` (the "x" is meant to remind you of
+"archive"). These are just wrapper functions around the public methods for the
+`epi_archive` R6 class. For example:
 
 - `epix_as_of()`, for generating a snapshot in `epi_df` format from the data
   archive, which represents the most up-to-date values of the signal variables,

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,9 +6,11 @@ url: https://cmu-delphi.github.io/epiprocess/
 home:
   links:
   - text: Get the epipredict R package
-    href: https://cmu-delphi.github.io/epiprocess/
+    href: https://cmu-delphi.github.io/epipredict/
   - text: Get the covidcast R package
     href: https://cmu-delphi.github.io/covidcast/covidcastR/
+  - text: Get the epidatr R package
+    href: https://github.com/cmu-delphi/epidatr
 
 articles:
 - title: Using the package
@@ -34,11 +36,11 @@ repo:
 
 
 reference:
-- title: epi_df basics
+- title: "`epi_df` basics"
   desc: Details on `epi_df` format, and basic functionality.
 - contents:
   - matches("epi_df")
-- title: epi_*() functions
+- title: "`epi_*()` functions"
   desc: Functions that act on `epi_df` objects.
 - contents:
   - epi_slide
@@ -50,11 +52,11 @@ reference:
   - detect_outlr
   - detect_outlr_rm
   - detect_outlr_stl
-- title: epi_archive basics
+- title: "`epi_archive` basics"
   desc: Details on `epi_archive`, and basic functionality.
 - contents:
   - matches("archive")
-- title: epix_*() functions
+- title: `epix_*()` functions
   desc: Functions that act on an `epi_archive` and/or `grouped_epi_archive` object.
 - contents:
   - starts_with("epix")

--- a/man/epi_slide.Rd
+++ b/man/epi_slide.Rd
@@ -71,9 +71,10 @@ return an object of class \code{lubridate::period}. For example, we can use
 contain the derivative values. Default is "slide_value"; note that setting
 \code{new_col_name} equal to an existing column name will overwrite this column.}
 
-\item{as_list_col}{Should the new column be stored as a list column? Default
-is \code{FALSE}, in which case a list object returned by \code{f} would be unnested
-(using \code{tidyr::unnest()}), and the names of the resulting columns are given
+\item{as_list_col}{If the computations return data frames, should the slide
+result hold these in a single list column or try to unnest them? Default is
+\code{FALSE}, in which case a list object returned by \code{f} would be unnested
+(using \code{\link[tidyr:nest]{tidyr::unnest()}}), and the names of the resulting columns are given
 by prepending \code{new_col_name} to the names of the list elements.}
 
 \item{names_sep}{String specifying the separator to use in \code{tidyr::unnest()}

--- a/man/epix_fill_through_version.Rd
+++ b/man/epix_fill_through_version.Rd
@@ -9,7 +9,7 @@ epix_fill_through_version(x, fill_versions_end, how = c("na", "locf"))
 \arguments{
 \item{x}{An \code{epi_archive}}
 
-\item{fill_versions_end}{Length-1, same class&type as \verb{\%s$version}: the
+\item{fill_versions_end}{Length-1, same class&type as \code{x$version}: the
 version through which to fill in missing version history; this will be the
 result's \verb{$versions_end} unless it already had a later
 \verb{$versions_end}.}

--- a/man/epix_slide.Rd
+++ b/man/epix_slide.Rd
@@ -74,9 +74,10 @@ would only be meaningful if \code{time_value} is of class \code{POSIXct}).}
 contain the derivative values. Default is "slide_value"; note that setting
 \code{new_col_name} equal to an existing column name will overwrite this column.}
 
-\item{as_list_col}{Should the new column be stored as a list column? Default
-is \code{FALSE}, in which case a list object returned by \code{f} would be unnested
-(using \code{tidyr::unnest()}), and the names of the resulting columns are given
+\item{as_list_col}{If the computations return data frames, should the slide
+result hold these in a single list column or try to unnest them? Default is
+\code{FALSE}, in which case a list object returned by \code{f} would be unnested
+(using \code{\link[tidyr:nest]{tidyr::unnest()}}), and the names of the resulting columns are given
 by prepending \code{new_col_name} to the names of the list elements.}
 
 \item{names_sep}{String specifying the separator to use in \code{tidyr::unnest()}

--- a/vignettes/aggregation.Rmd
+++ b/vignettes/aggregation.Rmd
@@ -243,7 +243,7 @@ head(xt_filled_month)
 TODO
 
 ## Attribution
-This document contains dataset that is a modified part of the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19) as [republished in the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html). This data set is licensed under the terms of the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/) by the Johns Hopkins University on behalf of its Center for Systems Science in Engineering. Copyright Johns Hopkins University 2020.
+This document contains a dataset that is a modified part of the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19) as [republished in the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html). This data set is licensed under the terms of the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/) by the Johns Hopkins University on behalf of its Center for Systems Science in Engineering. Copyright Johns Hopkins University 2020.
 
 [From the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html): 
  These signals are taken directly from the JHU CSSE [COVID-19 GitHub repository](https://github.com/CSSEGISandData/COVID-19) without changes. 

--- a/vignettes/archive.Rmd
+++ b/vignettes/archive.Rmd
@@ -30,6 +30,8 @@ library(epidatr)
 library(epiprocess)
 library(data.table)
 library(dplyr)
+library(purrr)
+library(ggplot2)
 
 dv <- covidcast(
   data_source = "doctor-visits",
@@ -48,6 +50,8 @@ library(epidatr)
 library(epiprocess)
 library(data.table)
 library(dplyr)
+library(purrr)
+library(ggplot2)
 ```
 
 ## Getting data into `epi_archive` format
@@ -141,15 +145,6 @@ as in `x$geo_type` or `x$time_type`, etc. Just like `as_epi_df()`, the function
 object is instantiated, if they are not explicitly specified in the function
 call (as it did in the case above).
 
-Note that `compactify` is **NOT** metadata and is an argument passed when creating
-the dataset, without being stored in the end:
-
-```{r,message=FALSE}
-# `dt` here is taken from the tests
-as_epi_archive(archive_cases_dv_subset$DT,compactify=TRUE)$geo_type # "state"
-as_epi_archive(archive_cases_dv_subset$DT,compactify=TRUE)$compactify # NULL
-```
-
 ## Producing snapshots in `epi_df` form
 
 A key method of an `epi_archive` class is `as_of()`, which generates a snapshot
@@ -189,8 +184,6 @@ marked by dotted vertical lines, and draw the latest curve in black (from the
 latest snapshot `x_latest` that the archive can provide).
 
 ```{r, fig.width = 8, fig.height = 7}
-library(purrr)
-library(ggplot2)
 theme_set(theme_bw())
 
 self_max = max(x$DT$version)
@@ -203,7 +196,7 @@ snapshots <- map_dfr(versions, function(v) {
 
 ggplot(snapshots %>% filter(!latest),
             aes(x = time_value, y = percent_cli)) +  
-  geom_line(aes(color = factor(version))) + 
+  geom_line(aes(color = factor(version)), na.rm=TRUE) + 
   geom_vline(aes(color = factor(version), xintercept = version), lty = 2) +
   facet_wrap(~ geo_value, scales = "free_y", ncol = 1) +
   scale_x_date(minor_breaks = "month", date_labels = "%b %y") +
@@ -211,7 +204,7 @@ ggplot(snapshots %>% filter(!latest),
   theme(legend.position = "none") +
   geom_line(data = snapshots %>% filter(latest),
                aes(x = time_value, y = percent_cli), 
-               inherit.aes = FALSE, color = "black")
+            inherit.aes = FALSE, color = "black", na.rm=TRUE)
 ```
 
 We can see some interesting and highly nontrivial revision behavior: at some
@@ -450,7 +443,7 @@ the vignettes in the current package are only meant to demo the slide
 functionality with some of the most basic forecasting methodology possible.
 
 ## Attribution
-This document contains dataset that is a modified part of the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19) as [republished in the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html). This data set is licensed under the terms of the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/) by the Johns Hopkins University on behalf of its Center for Systems Science in Engineering. Copyright Johns Hopkins University 2020.
+This document contains a dataset that is a modified part of the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19) as [republished in the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html). This data set is licensed under the terms of the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/) by the Johns Hopkins University on behalf of its Center for Systems Science in Engineering. Copyright Johns Hopkins University 2020.
 
 The `percent_cli` data is a modified part of the [COVIDcast Epidata API Doctor Visits data](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/doctor-visits.html). This dataset is licensed under the terms of the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/). Copyright Delphi Research Group at Carnegie Mellon University 2020.
 

--- a/vignettes/compactify.Rmd
+++ b/vignettes/compactify.Rmd
@@ -28,7 +28,7 @@ For this example, we have one chart using LOCF values, while another doesn't
 use them to illustrate LOCF. Notice how the head of the first dataset differs
 from the second from the third value included.
 
-```{r}
+```{r, message=FALSE}
 library(epiprocess)
 library(dplyr)
 

--- a/vignettes/correlation.Rmd
+++ b/vignettes/correlation.Rmd
@@ -22,14 +22,14 @@ library(dplyr)
 ```
 
 The data is fetched with the following query:
-```{r, message = FALSE, eval=F}
+```{r, message = FALSE}
 x <- covidcast(
   data_source = "jhu-csse",
   signals = "confirmed_7dav_incidence_prop",
   time_type = "day",
   geo_type = "state",
   time_values = epirange(20200301, 20211231),
-  geo_values = "ca,fl,ny,tx,ga,pa"
+  geo_values = "*"
 ) %>%
   fetch_tbl() %>%
   select(geo_value, time_value, case_rate = value)
@@ -40,25 +40,13 @@ y <- covidcast(
   time_type = "day",
   geo_type = "state",
   time_values = epirange(20200301, 20211231),
-  geo_values = "ca,fl,ny,tx,ga,pa"
+  geo_values = "*"
 ) %>%
   fetch_tbl() %>%
   select(geo_value, time_value, death_rate = value)
 
 x <- x %>%
   full_join(y, by = c("geo_value", "time_value")) %>%
-  as_epi_df()
-```
-
-The data has 4,026 rows and 4 columns.
-
-```{r, echo=FALSE}
-data(jhu_csse_daily_subset)
-x <- jhu_csse_daily_subset %>%
-  select(geo_value, time_value, 
-         case_rate = case_rate_7d_av,
-         death_rate = death_rate_7d_av) %>%
-  arrange(geo_value, time_value) %>%
   as_epi_df()
 ```
 
@@ -158,9 +146,9 @@ library(purrr)
 lags = 0:35
 
 z <- map_dfr(lags, function(lag) {
-  epi_cor(x, case_rate, death_rate, cor_by = geo_value, dt1 = -lag) %>% 
-    mutate(lag = lag) 
-  })
+  epi_cor(x, case_rate, death_rate, cor_by = geo_value, dt1 = -lag) %>%
+  mutate(lag = .env$lag)
+})
 
 z %>%
   group_by(lag) %>%
@@ -172,10 +160,10 @@ z %>%
 
 We can see that some pretty clear curvature here in the mean correlation between 
 case and death rates (where the correlations come from grouping by geo value) as
-a function of lag. The maximum occurs at a lag of somewhere around 18 days.
+a function of lag. The maximum occurs at a lag of somewhere around 17 days.
 
 ## Attribution
-This document contains dataset that is a modified part of the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19) as [republished in the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html). This data set is licensed under the terms of the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/) by the Johns Hopkins University on behalf of its Center for Systems Science in Engineering. Copyright Johns Hopkins University 2020.
+This document contains a dataset that is a modified part of the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19) as [republished in the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html). This data set is licensed under the terms of the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/) by the Johns Hopkins University on behalf of its Center for Systems Science in Engineering. Copyright Johns Hopkins University 2020.
 
 [From the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html): 
  These signals are taken directly from the JHU CSSE [COVID-19 GitHub repository](https://github.com/CSSEGISandData/COVID-19) without changes. 

--- a/vignettes/epiprocess.Rmd
+++ b/vignettes/epiprocess.Rmd
@@ -292,7 +292,7 @@ ggplot(x, aes(x = time_value, y = cases)) +
 
 
 ## Attribution
-This document contains dataset that is a modified part of the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19) as [republished in the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html). This data set is licensed under the terms of the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/) by the Johns Hopkins University on behalf of its Center for Systems Science in Engineering. Copyright Johns Hopkins University 2020.
+This document contains a dataset that is a modified part of the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19) as [republished in the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html). This data set is licensed under the terms of the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/) by the Johns Hopkins University on behalf of its Center for Systems Science in Engineering. Copyright Johns Hopkins University 2020.
 
 [From the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html): 
  These signals are taken directly from the JHU CSSE [COVID-19 GitHub repository](https://github.com/CSSEGISandData/COVID-19) without changes. 

--- a/vignettes/growth_rate.Rmd
+++ b/vignettes/growth_rate.Rmd
@@ -292,7 +292,7 @@ curve.
 working model for noise. *todo: write something intelligent here?* -->
 
 ## Attribution
-This document contains dataset that is a modified part of the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19) as [republished in the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html). This data set is licensed under the terms of the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/) by the Johns Hopkins University on behalf of its Center for Systems Science in Engineering. Copyright Johns Hopkins University 2020.
+This document contains a dataset that is a modified part of the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19) as [republished in the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html). This data set is licensed under the terms of the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/) by the Johns Hopkins University on behalf of its Center for Systems Science in Engineering. Copyright Johns Hopkins University 2020.
 
 [From the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html): 
  These signals are taken directly from the JHU CSSE [COVID-19 GitHub repository](https://github.com/CSSEGISandData/COVID-19) without changes.

--- a/vignettes/outliers.Rmd
+++ b/vignettes/outliers.Rmd
@@ -210,7 +210,7 @@ future.
 
 
 ## Attribution
-This document contains dataset that is a modified part of the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19) as [republished in the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html). This data set is licensed under the terms of the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/) by the Johns Hopkins University on behalf of its Center for Systems Science in Engineering. Copyright Johns Hopkins University 2020.
+This document contains a dataset that is a modified part of the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19) as [republished in the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html). This data set is licensed under the terms of the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/) by the Johns Hopkins University on behalf of its Center for Systems Science in Engineering. Copyright Johns Hopkins University 2020.
 
 [From the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html): 
  These signals are taken directly from the JHU CSSE [COVID-19 GitHub repository](https://github.com/CSSEGISandData/COVID-19) without changes. 

--- a/vignettes/slide.Rmd
+++ b/vignettes/slide.Rmd
@@ -292,7 +292,7 @@ example in the [archive
 vignette](https://cmu-delphi.github.io/epiprocess/articles/archive.html).
 
 ## Attribution
-This document contains dataset that is a modified part of the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19) as [republished in the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html). This data set is licensed under the terms of the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/) by the Johns Hopkins University on behalf of its Center for Systems Science in Engineering. Copyright Johns Hopkins University 2020.
+This document contains a dataset that is a modified part of the [COVID-19 Data Repository by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University](https://github.com/CSSEGISandData/COVID-19) as [republished in the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html). This data set is licensed under the terms of the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/) by the Johns Hopkins University on behalf of its Center for Systems Science in Engineering. Copyright Johns Hopkins University 2020.
 
 [From the COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html): 
  These signals are taken directly from the JHU CSSE [COVID-19 GitHub repository](https://github.com/CSSEGISandData/COVID-19) without changes. 


### PR DESCRIPTION
Keeping this in the `dev` branch as pushing to `main` will break `epipredict`, and it might make sense to incorporate repairs for the current breaking changes with those for some other planned breaking changes that are hopefully imminent. 