### PR TITLE
add epix_slide example comparing same computation with all_vers FALSE

### DIFF
--- a/R/methods-epi_archive.R
+++ b/R/methods-epi_archive.R
@@ -806,14 +806,34 @@ group_by.epi_archive = function(.data, ..., .add=FALSE, .drop=dplyr::group_by_dr
 #' # 2 `time_value`s, for the rest of the results
 #' # never 3 `time_value`s, due to data latency
 #'
-#'
+#' # Examining characteristics of the data passed to each computation with
+#' # `all_versions=FALSE`.
+#' archive_cases_dv_subset %>%
+#'  group_by(geo_value) %>%
+#'  epix_slide(
+#'    function(x, g) {
+#'      tibble(
+#'        time_range = if(nrow(x) == 0L) {
+#'          "0 `time_value`s"
+#'        } else {
+#'          sprintf("%s -- %s", min(x$time_value), max(x$time_value))
+#'        },
+#'        n = nrow(x),
+#'        class1 = class(x)[[1L]]
+#'      )
+#'    },
+#'    before = 5, all_versions = FALSE,
+#'    ref_time_values = ref_time_values, names_sep=NULL) %>%
+#'  ungroup() %>%
+#'  arrange(geo_value, time_value)
 #'
 #' # --- Advanced: ---
 #'
 #' # `epix_slide` with `all_versions=FALSE` (the default) applies a
 #' # version-unaware computation to several versions of the data. We can also
 #' # use `all_versions=TRUE` to apply a version-*aware* computation to several
-#' # versions of the data. In this case, each computation should expect an
+#' # versions of the data, again looking at characteristics of the data passed
+#' # to each computation. In this case, each computation should expect an
 #' # `epi_archive` containing the relevant version data:
 #'
 #' archive_cases_dv_subset %>%
@@ -821,16 +841,18 @@ group_by.epi_archive = function(.data, ..., .add=FALSE, .drop=dplyr::group_by_dr
 #'   epix_slide(
 #'     function(x, g) {
 #'       tibble(
+#'         versions_start = min(x$DT$version),
 #'         versions_end = max(x$versions_end),
 #'         time_range = if(nrow(x$DT) == 0L) {
 #'           "0 `time_value`s"
 #'         } else {
 #'           sprintf("%s -- %s", min(x$DT$time_value), max(x$DT$time_value))
 #'         },
+#'         n = nrow(x$DT),
 #'         class1 = class(x)[[1L]]
 #'       )
 #'     },
-#'     before = 2, all_versions = TRUE,
+#'     before = 5, all_versions = TRUE,
 #'     ref_time_values = ref_time_values, names_sep=NULL) %>%
 #'   ungroup() %>%
 #'   arrange(geo_value, time_value)

--- a/man/as_epi_df.Rd
+++ b/man/as_epi_df.Rd
@@ -52,9 +52,9 @@ examples.
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{as_epi_df(epi_df)}: Simply returns the \code{epi_df} object unchanged.
+\item \code{epi_df}: Simply returns the \code{epi_df} object unchanged.
 
-\item \code{as_epi_df(tbl_df)}: The input tibble \code{x} must contain the columns
+\item \code{tbl_df}: The input tibble \code{x} must contain the columns
 \code{geo_value} and \code{time_value}. All other columns will be preserved as is,
 and treated as measured variables. If \code{as_of} is missing, then the function
 will try to guess it from an \code{as_of}, \code{issue}, or \code{version} column of \code{x}
@@ -62,14 +62,14 @@ will try to guess it from an \code{as_of}, \code{issue}, or \code{version} colum
 (stored in its attributes); if this fails, then the current day-time will
 be used.
 
-\item \code{as_epi_df(data.frame)}: Works analogously to \code{as_epi_df.tbl_df()}.
+\item \code{data.frame}: Works analogously to \code{as_epi_df.tbl_df()}.
 
-\item \code{as_epi_df(tbl_ts)}: Works analogously to \code{as_epi_df.tbl_df()}, except that
+\item \code{tbl_ts}: Works analogously to \code{as_epi_df.tbl_df()}, except that
 the \code{tbl_ts} class is dropped, and any key variables (other than
 "geo_value") are added to the metadata of the returned object, under the
 \code{other_keys} field.
-
 }}
+
 \examples{
 # Convert a `tsibble` that has county code as an extra key
 # Notice that county code should be a character string to preserve any leading zeroes

--- a/man/as_epi_df.Rd
+++ b/man/as_epi_df.Rd
@@ -52,9 +52,9 @@ examples.
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{epi_df}: Simply returns the \code{epi_df} object unchanged.
+\item \code{as_epi_df(epi_df)}: Simply returns the \code{epi_df} object unchanged.
 
-\item \code{tbl_df}: The input tibble \code{x} must contain the columns
+\item \code{as_epi_df(tbl_df)}: The input tibble \code{x} must contain the columns
 \code{geo_value} and \code{time_value}. All other columns will be preserved as is,
 and treated as measured variables. If \code{as_of} is missing, then the function
 will try to guess it from an \code{as_of}, \code{issue}, or \code{version} column of \code{x}
@@ -62,14 +62,14 @@ will try to guess it from an \code{as_of}, \code{issue}, or \code{version} colum
 (stored in its attributes); if this fails, then the current day-time will
 be used.
 
-\item \code{data.frame}: Works analogously to \code{as_epi_df.tbl_df()}.
+\item \code{as_epi_df(data.frame)}: Works analogously to \code{as_epi_df.tbl_df()}.
 
-\item \code{tbl_ts}: Works analogously to \code{as_epi_df.tbl_df()}, except that
+\item \code{as_epi_df(tbl_ts)}: Works analogously to \code{as_epi_df.tbl_df()}, except that
 the \code{tbl_ts} class is dropped, and any key variables (other than
 "geo_value") are added to the metadata of the returned object, under the
 \code{other_keys} field.
-}}
 
+}}
 \examples{
 # Convert a `tsibble` that has county code as an extra key
 # Notice that county code should be a character string to preserve any leading zeroes

--- a/man/epix_slide.Rd
+++ b/man/epix_slide.Rd
@@ -198,14 +198,34 @@ archive_cases_dv_subset \%>\%
 # 2 `time_value`s, for the rest of the results
 # never 3 `time_value`s, due to data latency
 
-
+# Examining characteristics of the data passed to each computation with
+# `all_versions=FALSE`.
+archive_cases_dv_subset \%>\%
+ group_by(geo_value) \%>\%
+ epix_slide(
+   function(x, g) {
+     tibble(
+       time_range = if(nrow(x) == 0L) {
+         "0 `time_value`s"
+       } else {
+         sprintf("\%s -- \%s", min(x$time_value), max(x$time_value))
+       },
+       n = nrow(x),
+       class1 = class(x)[[1L]]
+     )
+   },
+   before = 5, all_versions = FALSE,
+   ref_time_values = ref_time_values, names_sep=NULL) \%>\%
+ ungroup() \%>\%
+ arrange(geo_value, time_value)
 
 # --- Advanced: ---
 
 # `epix_slide` with `all_versions=FALSE` (the default) applies a
 # version-unaware computation to several versions of the data. We can also
 # use `all_versions=TRUE` to apply a version-*aware* computation to several
-# versions of the data. In this case, each computation should expect an
+# versions of the data, again looking at characteristics of the data passed
+# to each computation. In this case, each computation should expect an
 # `epi_archive` containing the relevant version data:
 
 archive_cases_dv_subset \%>\%
@@ -213,16 +233,18 @@ archive_cases_dv_subset \%>\%
   epix_slide(
     function(x, g) {
       tibble(
+        versions_start = min(x$DT$version),
         versions_end = max(x$versions_end),
         time_range = if(nrow(x$DT) == 0L) {
           "0 `time_value`s"
         } else {
           sprintf("\%s -- \%s", min(x$DT$time_value), max(x$DT$time_value))
         },
+        n = nrow(x$DT),
         class1 = class(x)[[1L]]
       )
     },
-    before = 2, all_versions = TRUE,
+    before = 5, all_versions = TRUE,
     ref_time_values = ref_time_values, names_sep=NULL) \%>\%
   ungroup() \%>\%
   arrange(geo_value, time_value)

--- a/man/epix_slide.Rd
+++ b/man/epix_slide.Rd
@@ -182,6 +182,8 @@ ref_time_values <- seq(as.Date("2020-06-01"),
                        as.Date("2020-06-15"),
                        by = "1 day")
 
+# A simple (but not very useful) example (see the archive vignette for a more
+# realistic one):
 archive_cases_dv_subset \%>\%
   group_by(geo_value) \%>\%
   epix_slide(f = ~ mean(.x$case_rate_7d_av),
@@ -193,10 +195,14 @@ archive_cases_dv_subset \%>\%
 # values. The actual number of `time_value`s in each computation depends on
 # the reporting latency of the signal and `time_value` range covered by the
 # archive (2020-06-01 -- 2021-11-30 in this example).  In this case, we have
-# 0 `time_value`s, for ref time 2020-06-01 --> the result is automatically discarded
-# 1 `time_value`, for ref time 2020-06-02
-# 2 `time_value`s, for the rest of the results
-# never 3 `time_value`s, due to data latency
+# * 0 `time_value`s, for ref time 2020-06-01 --> the result is automatically
+#                                                discarded
+# * 1 `time_value`, for ref time 2020-06-02
+# * 2 `time_value`s, for the rest of the results
+# * never the 3 `time_value`s we would get from `epi_slide`, since, because
+#   of data latency, we'll never have an observation
+#   `time_value == ref_time_value` as of `ref_time_value`.
+# The example below shows this type of behavior in more detail.
 
 # Examining characteristics of the data passed to each computation with
 # `all_versions=FALSE`.
@@ -233,8 +239,12 @@ archive_cases_dv_subset \%>\%
   epix_slide(
     function(x, g) {
       tibble(
-        versions_start = min(x$DT$version),
-        versions_end = max(x$versions_end),
+        versions_start = if (nrow(x$DT) == 0L) {
+          "NA (0 rows)"
+        } else {
+          toString(min(x$DT$version))
+        },
+        versions_end = x$versions_end,
         time_range = if(nrow(x$DT) == 0L) {
           "0 `time_value`s"
         } else {
@@ -247,6 +257,8 @@ archive_cases_dv_subset \%>\%
     before = 5, all_versions = TRUE,
     ref_time_values = ref_time_values, names_sep=NULL) \%>\%
   ungroup() \%>\%
-  arrange(geo_value, time_value)
+  # Focus on one geo_value so we can better see the columns above:
+  filter(geo_value == "ca") \%>\%
+  select(-geo_value)
 
 }


### PR DESCRIPTION
Add example to `epix_slide` documentation comparing the same computation for `all_versions = TRUE` and `all_versions = FALSE`.