### PR TITLE
Attribute code borrowed/modified from `rlang` for use in `as_slide_computation`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Description: This package introduces a common data structure for epidemiological
     work with revisions to these data sets over time, and offers associated
     utilities to perform basic signal processing tasks.
 License: MIT + file LICENSE
-Copyright: file COPYRIGHTS
+Copyright: file inst/COPYRIGHTS
 Imports:
     cli,
     data.table,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,13 +16,15 @@ Authors@R: c(
     person("Dmitry", "Shemetov", role = "ctb"),
     person("Ryan", "Tibshirani", , "ryantibs@cmu.edu", role = c("aut", "cre")),
     person("Lionel", "Henry", role = "ctb", comment = "Author of included rlang fragments"),
-    person("Hadley", "Wickham", role = "ctb", comment = "Author of included rlang fragments")
+    person("Hadley", "Wickham", role = "ctb", comment = "Author of included rlang fragments"),
+    person("Posit", role = "cph", comment = "Copyright holder of included rlang fragments")
   )
 Description: This package introduces a common data structure for epidemiological
     data reported by location and time, provides another data structure to
     work with revisions to these data sets over time, and offers associated
     utilities to perform basic signal processing tasks.
 License: MIT + file LICENSE
+Copyright: file COPYRIGHTS
 Imports:
     cli,
     data.table,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,9 @@ Authors@R: c(
     person("Quang", "Nguyen", role = "ctb"),
     person("Evan", "Ray", role = "aut"),
     person("Dmitry", "Shemetov", role = "ctb"),
-    person("Ryan", "Tibshirani", , "ryantibs@cmu.edu", role = c("aut", "cre"))
+    person("Ryan", "Tibshirani", , "ryantibs@cmu.edu", role = c("aut", "cre")),
+    person("Lionel", "Henry", role = "ctb", comment = "Author of included rlang fragments"),
+    person("Hadley", "Wickham", role = "ctb", comment = "Author of included rlang fragments")
   )
 Description: This package introduces a common data structure for epidemiological
     data reported by location and time, provides another data structure to

--- a/R/utils.R
+++ b/R/utils.R
@@ -193,11 +193,11 @@ assert_sufficient_f_args <- function(f, ...) {
 #' extended to include `..3`; and also by `epi[x]_slide`-specific names
 #' `.group_key` and `.ref_time_value`.
 #'
-#' @source #' This code and documentation are based on the [`as_function`]
+#' @source This code and documentation are based on [`as_function`]
 #'  (https://github.com/r-lib/rlang/blob/c55f6027928d3104ed449e591e8a225fcaf55e13/R/fn.R#L343-L427)
 #'  function from Hadley Wickham's `rlang` package.
 #'
-#'  Below is the orginal license for the `rlang` package.
+#'  Below is the original license for the `rlang` package.
 #'
 #'
 #'  # MIT License

--- a/R/utils.R
+++ b/R/utils.R
@@ -187,16 +187,57 @@ assert_sufficient_f_args <- function(f, ...) {
 #'  quosure into a function; functions are returned as-is or with light
 #'  modifications to calculate `ref_time_value`.
 #'
-#' This code and documentation borrows heavily from [`rlang::as_function`]
-#' (https://github.com/r-lib/rlang/blob/c55f6027928d3104ed449e591e8a225fcaf55e13/R/fn.R#L343-L427).
-#'
 #' This code extends `rlang::as_function` to create functions that take three
 #' arguments. The arguments can be accessed via the idiomatic `.`, `.x`, and
 #' `.y`, extended to include `.z`; positional references `..1` and `..2`,
 #' extended to include `..3`; and also by `epi[x]_slide`-specific names
 #' `.group_key` and `.ref_time_value`.
 #'
-#' @source https://github.com/r-lib/rlang/blob/c55f6027928d3104ed449e591e8a225fcaf55e13/R/fn.R#L343-L427
+#' @source #' This code and documentation are based on the [`as_function`]
+#'  (https://github.com/r-lib/rlang/blob/c55f6027928d3104ed449e591e8a225fcaf55e13/R/fn.R#L343-L427)
+#'  function from Hadley Wickham's `rlang` package.
+#'
+#'  Below is the orginal license for the `rlang` package.
+#'
+#'
+#'  # MIT License
+#'
+#'  Copyright (c) 2020 rlang authors
+#'
+#'  Permission is hereby granted, free of charge, to any person obtaining a copy
+#'  of this software and associated documentation files (the "Software"), to deal
+#'  in the Software without restriction, including without limitation the rights
+#'  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#'  copies of the Software, and to permit persons to whom the Software is
+#'  furnished to do so, subject to the following conditions:
+#'
+#'  The above copyright notice and this permission notice shall be included in all
+#'  copies or substantial portions of the Software.
+#'
+#'  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#'  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#'  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#'  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#'  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#'  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#'  SOFTWARE.
+#'
+#'
+#'  Portions of the original code used in this adaptation:
+#'    1. Much of the documentation and examples
+#'    2. The general flow of the function, including branching conditions
+#'    3. Error conditions and wording
+#'    4. The chunk converting a formula into a function, see
+#'    https://github.com/r-lib/rlang/blob/c55f6027928d3104ed449e591e8a225fcaf55e13/R/fn.R#L411-L418
+#'
+#'  Changes made include:
+#'    1. Updates to documentation due to new functionality
+#'    2. The removal of function-as-string processing logic and helper arg
+#'    `env`
+#'    3. The addition of an output function wrapper that defines a data mask
+#'    for evaluating quosures
+#'    4. Calling an argument-checking function
+#'    5. Replacing rlang error functions with internal error functions
 #'
 #' @param .f A function, one-sided formula, or quosure.
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -193,14 +193,14 @@ assert_sufficient_f_args <- function(f, ...) {
 #' extended to include `..3`; and also by `epi[x]_slide`-specific names
 #' `.group_key` and `.ref_time_value`.
 #'
-#' @source This code and documentation are based on [`as_function`]
-#'  (https://github.com/r-lib/rlang/blob/c55f6027928d3104ed449e591e8a225fcaf55e13/R/fn.R#L343-L427)
-#'  function from Hadley Wickham's `rlang` package.
+#' @source This code and documentation are based on
+#'  [`as_function`](https://github.com/r-lib/rlang/blob/c55f6027928d3104ed449e591e8a225fcaf55e13/R/fn.R#L343-L427)
+#'  from Hadley Wickham's `rlang` package.
 #'
 #'  Below is the original license for the `rlang` package.
 #'
 #'
-#'  # MIT License
+#'  MIT License
 #'
 #'  Copyright (c) 2020 rlang authors
 #'

--- a/inst/COPYRIGHTS
+++ b/inst/COPYRIGHTS
@@ -1,0 +1,26 @@
+Copyright for most of the included code is held by the Delphi group.
+
+Posit is the copyright holder for `rlang` fragments included in the
+`as_slide_computation` function in `utils.R` under the following license.
+
+# MIT License
+
+Copyright (c) 2020 rlang authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/inst/COPYRIGHTS
+++ b/inst/COPYRIGHTS
@@ -1,7 +1,7 @@
 Copyright for most of the included code is held by the Delphi group.
 
 Posit is the copyright holder for `rlang` fragments included in the
-`as_slide_computation` function in `utils.R` under the following license.
+`as_slide_computation` function and documentation in `utils.R` under the following license.
 
 # MIT License
 

--- a/inst/COPYRIGHTS
+++ b/inst/COPYRIGHTS
@@ -1,7 +1,5 @@
-Copyright for most of the included code is held by the Delphi group.
-
 Posit is the copyright holder for `rlang` fragments included in the
-`as_slide_computation` function and documentation in `utils.R` under the following license.
+`as_slide_computation` function and documentation in `utils.R` under the following license:
 
 # MIT License
 

--- a/man/epi_slide.Rd
+++ b/man/epi_slide.Rd
@@ -76,9 +76,9 @@ contain the derivative values. Default is "slide_value"; note that setting
 \code{new_col_name} equal to an existing column name will overwrite this column.}
 
 \item{as_list_col}{Should the slide results be held in a list column, or be
-\link[tidyr:chop]{unchopped}/\link[tidyr:nest]{unnested}? Default is \code{FALSE},
+\link[tidyr:chop]{unchopped}/\link[tidyr:unnest]{unnested}? Default is \code{FALSE},
 in which case a list object returned by \code{f} would be unnested (using
-\code{\link[tidyr:nest]{tidyr::unnest()}}), and, if the slide computations output data frames,
+\code{\link[tidyr:unnest]{tidyr::unnest()}}), and, if the slide computations output data frames,
 the names of the resulting columns are given by prepending \code{new_col_name}
 to the names of the list elements.}
 

--- a/man/epix_slide.Rd
+++ b/man/epix_slide.Rd
@@ -80,9 +80,9 @@ contain the derivative values. Default is "slide_value"; note that setting
 \code{new_col_name} equal to an existing column name will overwrite this column.}
 
 \item{as_list_col}{Should the slide results be held in a list column, or be
-\link[tidyr:chop]{unchopped}/\link[tidyr:nest]{unnested}? Default is \code{FALSE},
+\link[tidyr:chop]{unchopped}/\link[tidyr:unnest]{unnested}? Default is \code{FALSE},
 in which case a list object returned by \code{f} would be unnested (using
-\code{\link[tidyr:nest]{tidyr::unnest()}}), and, if the slide computations output data frames,
+\code{\link[tidyr:unnest]{tidyr::unnest()}}), and, if the slide computations output data frames,
 the names of the resulting columns are given by prepending \code{new_col_name}
 to the names of the list elements.}
 

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -23,7 +23,7 @@ below to see their documentation.
 \describe{
   \item{dplyr}{\code{\link[dplyr]{arrange}}, \code{\link[dplyr]{filter}}, \code{\link[dplyr]{group_by}}, \code{\link[dplyr:group_map]{group_modify}}, \code{\link[dplyr]{mutate}}, \code{\link[dplyr]{relocate}}, \code{\link[dplyr]{rename}}, \code{\link[dplyr]{slice}}, \code{\link[dplyr:group_by]{ungroup}}}
 
-  \item{tidyr}{\code{\link[tidyr:nest]{unnest}}}
+  \item{tidyr}{\code{\link[tidyr]{unnest}}}
 
   \item{tsibble}{\code{\link[tsibble:as-tsibble]{as_tsibble}}}
 }}


### PR DESCRIPTION
### Description
Add `rlang` authors and copyright holder to DESCRIPTION file. Add COPYRIGHT file. Add `rlang` license text to the documentation for `as_slide_computation`, noting aspects of the original code that were kept and changed.

### Fixes
Partially addresses https://github.com/cmu-delphi/epiprocess/issues/327