### PR TITLE
ci: stop building pkgdown on forks

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -15,6 +15,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
+    # only build docs on the main repository and not forks
     if: github.repository_owner == 'cmu-delphi'
     runs-on: ubuntu-latest
     # Only restrict concurrency for non-PR jobs

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -15,6 +15,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
+    if: github.repository_owner == 'cmu-delphi'
     runs-on: ubuntu-latest
     # Only restrict concurrency for non-PR jobs
     concurrency:


### PR DESCRIPTION
This makes it so that pkgdown will only run if the repo is owned by cmu-delphi directly. I'd rather pkgdown stopped trying to run on my fork whenever I sync it with main or dev, causing failing build notifications. This should solve it, taken from [here](https://github.com/orgs/community/discussions/26409), and working on epidatr.