### PR TITLE
docs: update news for 0.7.0 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,10 +52,10 @@ inter-release development versions will include an additional ".9000" suffix.
   format (see `tidyr::chop`).
 * `epi_slide` now works properly with slide computations that output just a
   `Date` vector, rather than converting `slide_value` to a numeric column.
-* Fix `?archive_cases_dv_subset` regarding modifications of upstream by
-  @brookslogan in (#299)
-* Update to use latest `epidatr` (`fetch_tbl` -> `fetch`) by @brookslogan in
-  (#319)
+* Fix `?archive_cases_dv_subset` information regarding modifications of upstream
+  data by @brookslogan in (#299).
+* Update to use updated `epidatr` (`fetch_tbl` -> `fetch`) by @brookslogan in
+  (#319).
 
 # epiprocess 0.6.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 Note that `epiprocess` uses the [Semantic Versioning
 ("semver")](https://semver.org/) scheme for all release versions, but any
-inter-release development versions will include an additional ".9000" suffix.
+inter-release development versions will include an additional ".9999" suffix.
 
 ## Breaking changes:
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 Note that `epiprocess` uses the [Semantic Versioning
 ("semver")](https://semver.org/) scheme for all release versions, but any
-inter-release development versions will include an additional ".9999" suffix.
+inter-release development versions will include an additional ".9000" suffix.
 
 ## Breaking changes:
 
@@ -21,9 +21,9 @@ inter-release development versions will include an additional ".9999" suffix.
 
 ## New features:
 
-* `epi_slide` and `epix_slide` also make the window data, group key and reference
-  time value available to slide computations specified as formulas or tidy
-  evaluation expressions, in additional or completely new ways.
+* `epi_slide` and `epix_slide` also make the window data, group key and
+  reference time value available to slide computations specified as formulas or
+  tidy evaluation expressions, in additional or completely new ways.
   * If `f` is a formula, it can now access the reference time value via `.z` or
     `.ref_time_value`.
   * If `f` is missing, the tidy evaluation expression in `...` can now refer to
@@ -52,6 +52,10 @@ inter-release development versions will include an additional ".9999" suffix.
   format (see `tidyr::chop`).
 * `epi_slide` now works properly with slide computations that output just a
   `Date` vector, rather than converting `slide_value` to a numeric column.
+* Fix `?archive_cases_dv_subset` regarding modifications of upstream by
+  @brookslogan in (#299)
+* Update to use latest `epidatr` (`fetch_tbl` -> `fetch`) by @brookslogan in
+  (#319)
 
 # epiprocess 0.6.0
 


### PR DESCRIPTION
Since `main` is already on 0.7.0 and it's stable-enough, we should make it a release. This updates the NEWS with a few bullets from the release notes generated by the current `main` branch. 

After we merge this, we can make a release 0.7.0, then bump the dev branch to 0.7.0.9000 (see Nat's comment in #383) and starting adding PR change lines under that heading.