### PR TITLE
Disable auto review assignment, add PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @dajmcdon @brookslogan

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+### Checklist
+
+Please:
+- [ ] Request a review from one of the current epiprocess main reviewers: brookslogan, nmdefries.
+- [ ] Describe changes made in NEWS.md or under the "Changelog" heading, making
+      sure breaking changes (backwards-incompatible changes to the documented
+      interface) are noted. The right location for this may be in flux (see
+      [here](https://github.com/cmu-delphi/epiprocess/pull/398)).
+
+### Changelog (if not put in NEWS.md)
+
+### Magic GitHub syntax to resolve Issues on merge
+
+- Resolves #{issue number}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,5 @@ Please:
 ### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch
 
 - Resolves #{issue number}
+
+### Context / Other notes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,8 @@
 ### Checklist
 
 Please:
-- [ ] Request a review from one of the current epiprocess main reviewers: brookslogan, nmdefries.
+- [ ] Request a review from one of the current epiprocess main reviewers:
+      brookslogan, nmdefries.
 - [ ] Describe changes made in NEWS.md or under the "Changelog" heading, making
       sure breaking changes (backwards-incompatible changes to the documented
       interface) are noted. The right location for this may be in flux (see

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 ### Checklist
 
 Please:
+- [ ] Make sure this PR is against "dev", not "main".
 - [ ] Request a review from one of the current epiprocess main reviewers:
       brookslogan, nmdefries.
 - [ ] Describe changes made in NEWS.md or under the "Changelog" heading, making

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,9 +4,9 @@ Please:
 - [ ] Make sure this PR is against "dev", not "main".
 - [ ] Request a review from one of the current epiprocess main reviewers:
       brookslogan, nmdefries.
-- [ ] Describe changes made in NEWS.md, making
-      sure breaking changes (backwards-incompatible changes to the documented
-      interface) are noted. The right location for this may be in flux (see
+- [ ] Describe changes made in NEWS.md, making sure breaking changes
+      (backwards-incompatible changes to the documented interface) are noted.
+      The right location for this may be in flux (see
       [here](https://github.com/cmu-delphi/epiprocess/pull/398)).
 
 ### Change explanations for reviewer

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,12 +4,12 @@ Please:
 - [ ] Make sure this PR is against "dev", not "main".
 - [ ] Request a review from one of the current epiprocess main reviewers:
       brookslogan, nmdefries.
-- [ ] Describe changes made in NEWS.md or under the "Changelog" heading, making
+- [ ] Describe changes made in NEWS.md, making
       sure breaking changes (backwards-incompatible changes to the documented
       interface) are noted. The right location for this may be in flux (see
       [here](https://github.com/cmu-delphi/epiprocess/pull/398)).
 
-### Changelog (if not put in NEWS.md)
+### Change explanations for reviewer
 
 ### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,6 @@ Please:
 
 ### Changelog (if not put in NEWS.md)
 
-### Magic GitHub syntax to resolve Issues on merge
+### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch
 
 - Resolves #{issue number}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,5 +14,3 @@ Please:
 ### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch
 
 - Resolves #{issue number}
-
-### Context / Other notes


### PR DESCRIPTION
Disable auto review requests to CODEOWNERS by removing the file altogether.