### PR TITLE
patch version bumper for branch permissions

### DIFF
--- a/.github/workflows/auto_semver_bump.yaml
+++ b/.github/workflows/auto_semver_bump.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       # Checkout action is required
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.2
         with:
           ssh-key: ${{ secrets.SEMVER_BUMPER_KEY }}
       - uses: actions/setup-node@v1

--- a/.github/workflows/auto_semver_bump.yaml
+++ b/.github/workflows/auto_semver_bump.yaml
@@ -22,5 +22,4 @@ jobs:
         uses: michmich112/version-bumper@master
         with:
           options-file: "./.github/version_bump_options.json"
-          ssh-key: ${{ secrets.SEMVER_BUMPER_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto_semver_bump.yaml
+++ b/.github/workflows/auto_semver_bump.yaml
@@ -14,7 +14,7 @@ jobs:
       # Checkout action is required
       - uses: actions/checkout@v3.5.2
         with:
-          ssh-key: ${{ secrets.SEMVER_BUMPER_KEY }}
+          token: ${{ secrets.DMITRY_PAT }}
       - uses: actions/setup-node@v1
         with:
           node-version: "12"

--- a/.github/workflows/auto_semver_bump.yaml
+++ b/.github/workflows/auto_semver_bump.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       # Checkout action is required
       - uses: actions/checkout@v2
+        with:
+          ssh-key: ${{ secrets.SEMVER_BUMPER_KEY }}
       - uses: actions/setup-node@v1
         with:
           node-version: "12"
@@ -20,4 +22,5 @@ jobs:
         uses: michmich112/version-bumper@master
         with:
           options-file: "./.github/version_bump_options.json"
+          ssh-key: ${{ secrets.SEMVER_BUMPER_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
not sure if this is quite the right way. I also added a repo secret `SEMVER_BUMPER_KEY`, which has both a [secret](https://github.com/cmu-delphi/epiprocess/settings/secrets/actions) and a [deploy key](https://github.com/cmu-delphi/epiprocess/settings/keys) with write access