### PR TITLE
Guess YYYYww numeric as "custom", fix incidental typo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: epiprocess
 Title: Tools for basic signal processing in epidemiology
-Version: 0.7.7
+Version: 0.7.8
 Authors@R: c(
     person("Jacob", "Bien", role = "ctb"),
     person("Logan", "Brooks", email = "lcbrooks@andrew.cmu.edu", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,7 +27,8 @@ Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.x.y will indicat
   the `epi_df` (#382).
 - Refactored internals to use `cli` for warnings/errors and `checkmate` for
   argument checking (#413).
-- Fix logic to auto-assign `ep_df` `time_type` to `week` (#416).
+- Fix logic to auto-assign `epi_df` `time_type` to `week` (#416) and `year`
+  (#441).
 
 ## Breaking changes
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -403,7 +403,7 @@ guess_geo_type <- function(geo_value) {
 guess_time_type <- function(time_value) {
   # Convert character time values to Date or POSIXct
   if (is.character(time_value)) {
-    if (nchar(time_value[1]) <= "10") {
+    if (nchar(time_value[1]) <= 10L) {
       new_time_value <- tryCatch(
         {
           as.Date(time_value)
@@ -440,14 +440,8 @@ guess_time_type <- function(time_value) {
     return("yearmonth")
   } else if (inherits(time_value, "yearquarter")) {
     return("yearquarter")
-  }
-
-  # Else, if it's an integer that's at least 1582, then use "year"
-  if (
-    is.numeric(time_value) &&
-      all(time_value == as.integer(time_value)) &&
-      all(time_value >= 1582)
-  ) {
+  } else if (rlang::is_integerish(time_value) &&
+    all(nchar(as.character(time_value)) == 4L)) { # nolint: indentation_linter
     return("year")
   }
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -56,6 +56,10 @@ test_that("guess_time_type works for different types", {
   yearquarters <- tsibble::yearquarter(10)
 
   years <- c(1999, 2000)
+  ambiguous_yearweeks <- c(199901, 199902) # -> "custom"
+
+  daytimes <- as.POSIXct(c("2022-01-01 05:00:00", "2022-01-01 15:0:00"), tz = "UTC")
+  daytimes_chr <- as.character(daytimes)
 
   # YYYY-MM-DD is the accepted format
   not_ymd1 <- "January 1, 2022"
@@ -72,13 +76,17 @@ test_that("guess_time_type works for different types", {
   expect_equal(guess_time_type(yearquarters), "yearquarter")
 
   expect_equal(guess_time_type(years), "year")
+  expect_equal(guess_time_type(ambiguous_yearweeks), "custom")
+
+  expect_equal(guess_time_type(daytimes), "day-time")
+  expect_equal(guess_time_type(daytimes_chr), "day-time")
 
   expect_equal(guess_time_type(not_ymd1), "custom")
   expect_equal(guess_time_type(not_ymd2), "custom")
   expect_equal(guess_time_type(not_ymd3), "custom")
   expect_equal(guess_time_type(not_a_date), "custom")
 })
-3
+
 test_that("guess_time_type works with gaps", {
   days_gaps <- as.Date("2022-01-01") + c(0, 1, 3, 4, 8, 8 + 7)
   weeks_gaps <- as.Date("2022-01-01") + 7 * c(0, 1, 3, 4, 8, 8 + 7)


### PR DESCRIPTION
- Previously we guessed YYYYww numeric as "year", almost surely wrong. But we can't easily/reliably tell what type of yearweek it is, so just use "custom" to avoid various/bad guesses in time_type-reliant code.
- Don't use <int> <= <chr>; seemed nonimpactful in this case, at least in tested locale.

### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current main reviewers:
      brookslogan, nmdefries.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).
- See [DEVELOPMENT.md](DEVELOPMENT.md) for more information on the development
  process.

### Change explanations for reviewer

- Previously we guessed YYYYww numerics as "year"s.  Probably wrong.
- Don't use '<= "10"' --- this didn't seem to have an impact, but still seems cleaner.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch
