### PR TITLE
Address Guidehouse feedback on landing page

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: epiprocess
 Title: Tools for basic signal processing in epidemiology
-Version: 0.7.9
+Version: 0.7.10
 Authors@R: c(
     person("Jacob", "Bien", role = "ctb"),
     person("Logan", "Brooks", email = "lcbrooks@andrew.cmu.edu", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@ Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.x.y will indicat
   (#441).
 - Clarified "Get started" example of getting Ebola line list data into `epi_df`
   format.
+- Improved documentation web site landing page's introduction.
 
 # epiprocess 0.7.0
 

--- a/vignettes/epiprocess.Rmd
+++ b/vignettes/epiprocess.Rmd
@@ -9,16 +9,21 @@ editor_options:
   chunk_output_type: console
 ---
 
-The [`{epiprocess}`](https://cmu-delphi.github.io/epiprocess/) package provides
+The [`{epiprocess}`](https://cmu-delphi.github.io/epiprocess/) package works
+with epidemiological time series and version data to provide situational
+awareness, processing and transformations in preparation for modeling, and
+version-faithful model backtesting.  It contains:
 
 - `epi_df`, a class for working with epidemiological time series data;
 - `epi_archive`, a class for working with the version history of such time series data;
 - sample data in these formats;
-- functions for common data transformations (e.g., 7-day averages);
+- [`{dplyr}`](https://dplyr.tidyverse.org/)-esque "verbs" for common data
+  transformations (e.g., 7-day averages);
 - functions for exploratory data analysis and situational awareness (e.g.,
   outlier detection and growth rate estimation); and
-- functions for version-faithful "pseudoprospective" backtesting of models, and
-  other version history analysis.
+- [`{dplyr}`](https://dplyr.tidyverse.org/)-esque "verbs" for version-faithful
+  "pseudoprospective" backtesting of models, and other version history analysis
+  and transformations.
 
 It is part of a broader suite of packages including
 [`{epidatr}`](https://cmu-delphi.github.io/epidatr/),

--- a/vignettes/epiprocess.Rmd
+++ b/vignettes/epiprocess.Rmd
@@ -9,14 +9,56 @@ editor_options:
   chunk_output_type: console
 ---
 
-This package introduces a common data structure for epidemiological data sets
-measured over space and time, and offers associated utilities to perform basic
-signal processing tasks.
+The [`{epiprocess}`](https://cmu-delphi.github.io/epiprocess/) package provides
+
+- `epi_df`, a class for working with epidemiological time series data;
+- `epi_archive`, a class for working with the version history of such time series data;
+- sample data in these formats;
+- functions for common data transformations (e.g., 7-day averages);
+- functions for exploratory data analysis and situational awareness (e.g.,
+  outlier detection and growth rate estimation); and
+- functions for version-faithful "pseudoprospective" backtesting of models, and
+  other version history analysis.
+
+It is part of a broader suite of packages including
+[`{epidatr}`](https://cmu-delphi.github.io/epidatr/),
+[`{epidatasets}`](https://cmu-delphi.github.io/epidatasets/),
+[`{rtestim}`](https://dajmcdon.github.io/rtestim/), and
+[`{epipredict}`](https://cmu-delphi.github.io/epipredict/), for accessing,
+analyzing, and forecasting epidemiological time series data. We have expanded
+documentation and demonstrations for some of these packages available in an
+online "book" format [here](https://cmu-delphi.github.io/delphi-tooling-book/).
+
+## Motivation
+
+[`{epiprocess}`](https://cmu-delphi.github.io/epiprocess/) and
+[`{epipredict}`](https://cmu-delphi.github.io/epipredict/) are designed to lower
+the barrier to entry and implementation cost for epidemiological time series
+analysis and forecasting. Epidemiologists and forecasting groups repeatedly and
+separately have had to rush to implement this type of functionality in a much
+more ad hoc manner; we are trying to save such effort in the future by providing
+well-documented, tested, and general packages that can be called for many common
+tasks instead.
+
+[`{epiprocess}`](https://github.com/cmu-delphi/epiprocess/) also provides tools
+to help avoid a particularly common pitfall in analysis and forecasting:
+ignoring reporting latency and revisions to a data set. This can, for example,
+lead to one retrospectively analyzing a surveillance signal or forecasting model
+and concluding that it is much more accurate than it actually was in real time,
+or producing always-decreasing forecasts on data sets where initial surveillance
+estimates are systematically revised upward. Storing and working with version
+history can help avoid these issues.
+
+## Intended audience
+
+We expect users to be proficient in R, and familiar with the
+[`{dplyr}`](https://dplyr.tidyverse.org/) and
+[`{tidyr}`](https://tidyr.tidyverse.org/) packages.
 
 ## Installing
 
 This package is not on CRAN yet, so it can be installed using the
-[`devtools`](https://devtools.r-lib.org) package:
+[`{devtools}`](https://devtools.r-lib.org) package:
 
 ```{r, eval = FALSE}
 devtools::install_github("cmu-delphi/epiprocess", ref = "main")

--- a/vignettes/epiprocess.Rmd
+++ b/vignettes/epiprocess.Rmd
@@ -25,11 +25,11 @@ version-faithful model backtesting.  It contains:
   "pseudoprospective" backtesting of models, and other version history analysis
   and transformations.
 
-It is part of a broader suite of packages including
+It is part of a broader suite of packages that includes
+[`{epipredict}`](https://cmu-delphi.github.io/epipredict/),
 [`{epidatr}`](https://cmu-delphi.github.io/epidatr/),
-[`{epidatasets}`](https://cmu-delphi.github.io/epidatasets/),
 [`{rtestim}`](https://dajmcdon.github.io/rtestim/), and
-[`{epipredict}`](https://cmu-delphi.github.io/epipredict/), for accessing,
+[`{epidatasets}`](https://cmu-delphi.github.io/epidatasets/), for accessing,
 analyzing, and forecasting epidemiological time series data. We have expanded
 documentation and demonstrations for some of these packages available in an
 online "book" format [here](https://cmu-delphi.github.io/delphi-tooling-book/).


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current main reviewers:
      brookslogan, nmdefries.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).
- See [DEVELOPMENT.md](DEVELOPMENT.md) for more information on the development
  process.

### Change explanations for reviewer

This addresses some feedback we received from Guidehouse on the landing page; here are my notes:
- We should provide more context on landing page: why, what need, what ?? addresses; highlighting more e.g. the top 2 novel features.
- Useful in landing page to have a little more detail e.g. about 7dav-ing?
- Add to landing page the expected level we expect people to have to use the package (we expect people to be able to use these packages in R that are very common e.g., dplyr and tidyr).

There is some slightly-awkward link spam for `{epiprocess}` and `{epipredict}` so that we retain braces around all package names; if we don't manually turn them into links, then they will [automatically be turned into links anyway and have the braces dropped](https://github.com/r-lib/downlit/issues/176) (and a slightly worse link for epipredict, probably because we list the repo URL before the github.io URL in the DESCRIPTION file).

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

