### PR TITLE
`slide.Rmd` seems to contain legacy info on `epi_slide`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,11 @@ Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.x.y will indicat
 - Clarified "Get started" example of getting Ebola line list data into `epi_df`
   format.
 - Improved documentation web site landing page's introduction.
+- Fixed documentation referring to old `epi_slide()` interface (#466, thanks
+  @XuedaShen!).
+
+## Cleanup
+- Resolved some linting messages in package checks (#468).
 
 # epiprocess 0.7.0
 

--- a/vignettes/slide.Rmd
+++ b/vignettes/slide.Rmd
@@ -21,8 +21,7 @@ as `Date` objects, then one time step is one day, since `as.Date("2022-01-01") +
 1` equals `as.Date("2022-01-02")`. Alternatively, the time step can be specified
 manually in the call to `epi_slide()`; you can read the documentation for more
 details. Furthermore, the alignment of the running window used in `epi_slide()`
-can be "right", "center", or "left"; the default is "right", and is what we use
-in this vignette.
+is specified by `before` and `after`. 
 
 As in getting started guide, we'll fetch daily reported COVID-19 cases from CA,
 FL, NY, and TX (note: here we're using new, not cumulative cases) using the


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current main reviewers:
      brookslogan, nmdefries.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).
- See [DEVELOPMENT.md](DEVELOPMENT.md) for more information on the development
  process.

### Change explanations for reviewer

Minor update on `slide.Rmd`, removes reference to `left` and `right` and change to `before` and `after`.  

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #{issue number}
