### PR TITLE
Assign to dots using `assign` to avoid CI warning

### DIFF
--- a/R/grouped_epi_archive.R
+++ b/R/grouped_epi_archive.R
@@ -317,7 +317,10 @@ epix_slide.grouped_epi_archive <- function(x, f, ..., before, ref_time_values,
 
     f <- quos[[1]]
     new_col <- sym(names(rlang::quos_auto_name(quos)))
-    ... <- missing_arg() # nolint: object_usage_linter. magic value that passes zero args as dots in calls below
+    # Magic value that passes zero args as dots in calls below. Equivalent to
+    # `... <- missing_arg()`, but use `assign` to avoid warning about
+    # improper use of dots.
+    assign("...", missing_arg())
   }
 
   f <- as_slide_computation(f, ...)

--- a/R/slide.R
+++ b/R/slide.R
@@ -304,7 +304,10 @@ epi_slide <- function(x, f, ..., before, after, ref_time_values,
 
     f <- quos[[1]]
     new_col <- sym(names(rlang::quos_auto_name(quos)))
-    ... <- missing_arg() # magic value that passes zero args as dots in calls below # nolint: object_usage_linter
+    # Magic value that passes zero args as dots in calls below. Equivalent to
+    # `... <- missing_arg()`, but use `assign` to avoid warning about
+    # improper use of dots.
+    assign("...", missing_arg())
   }
 
   f <- as_slide_computation(f, ...)


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current main reviewers:
      brookslogan, nmdefries.
- [ ] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [ ] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).
- See [DEVELOPMENT.md](DEVELOPMENT.md) for more information on the development
  process.

### Change explanations for reviewer
`... <- missing_arg()` consistently causes warning in tests `Warning: : ... may be used in an incorrect context`. Switch to another way of assigning to the variable `...` to avoid this.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch
Closes https://github.com/cmu-delphi/epiprocess/issues/465
