### PR TITLE
test grouping only before tsibble 1.1.5

### DIFF
--- a/tests/testthat/test-as_tibble-decay.R
+++ b/tests/testthat/test-as_tibble-decay.R
@@ -8,6 +8,7 @@ test_that("as_tibble checks an attr to avoid decay to tibble", {
 })
 
 test_that("as_tibble ungroups if needed", {
+  skip_if(packageVersion("tsibble") > "1.1.4")
   edf <- jhu_csse_daily_subset %>% group_by(geo_value)
   # removes the grouped_df class
   expect_identical(class(as_tibble(edf)), c("tbl_df", "tbl", "data.frame"))

--- a/tests/testthat/test-as_tibble-decay.R
+++ b/tests/testthat/test-as_tibble-decay.R
@@ -8,6 +8,7 @@ test_that("as_tibble checks an attr to avoid decay to tibble", {
 })
 
 test_that("as_tibble ungroups if needed", {
+  # tsibble is doing some method piracy, and overwriting as_tibble.grouped_df as of 1.1.5
   skip_if(packageVersion("tsibble") > "1.1.4")
   edf <- jhu_csse_daily_subset %>% group_by(geo_value)
   # removes the grouped_df class

--- a/tests/testthat/test-methods-epi_df.R
+++ b/tests/testthat/test-methods-epi_df.R
@@ -131,6 +131,7 @@ test_that("Metadata is dropped by `as_tibble`", {
 })
 
 test_that("Grouping are dropped by `as_tibble`", {
+  # tsibble is doing some method piracy, and overwriting as_tibble.grouped_df as of 1.1.5
   skip_if(packageVersion("tsibble") > "1.1.4")
   grouped_converted <- toy_epi_df %>%
     group_by(geo_value) %>%

--- a/tests/testthat/test-methods-epi_df.R
+++ b/tests/testthat/test-methods-epi_df.R
@@ -121,7 +121,17 @@ test_that("Correct metadata when subset includes some of other_keys", {
   # Including both original other_keys was already tested above
 })
 
-test_that("Metadata and grouping are dropped by `as_tibble`", {
+test_that("Metadata is dropped by `as_tibble`", {
+  grouped_converted <- toy_epi_df %>%
+    group_by(geo_value) %>%
+    as_tibble()
+  expect_true(
+    !any(c("metadata") %in% names(attributes(grouped_converted)))
+  )
+})
+
+test_that("Grouping are dropped by `as_tibble`", {
+  skip_if(packageVersion("tsibble") > "1.1.4")
   grouped_converted <- toy_epi_df %>%
     group_by(geo_value) %>%
     as_tibble()


### PR DESCRIPTION
### Checklist

Please:

- [X] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [X] Request a review from one of the current main reviewers:
      brookslogan, nmdefries.
- [X] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [X] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).
- See [DEVELOPMENT.md](DEVELOPMENT.md) for more information on the development
  process.

### Change explanations for reviewer

Not bumping the version or adding to NEWS because it only changes tests, and is strictly upstream changes.

I added a skip that only tests for grouping's presence if the version of `tsibble` is before 1.1.5 specifically.
