### PR TITLE
fix: `before=Inf` in opt functions now actually works

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: epiprocess
 Title: Tools for basic signal processing in epidemiology
-Version: 0.8.1
+Version: 0.8.2
 Authors@R: c(
     person("Jacob", "Bien", role = "ctb"),
     person("Logan", "Brooks", email = "lcbrooks@andrew.cmu.edu", role = c("aut", "cre")),
@@ -32,6 +32,7 @@ Imports:
     dplyr (>= 1.0.0),
     genlasso,
     ggplot2,
+    glue,
     lifecycle (>= 1.0.1),
     lubridate,
     magrittr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,12 @@ Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.x.y will indicat
 - Added `complete.epi_df`, which fills in missing values in an `epi_df` with
   `NA`s. Uses `tidyr::complete` underneath and preserves `epi_df` metadata.
 
+## Bug fixes
+
+- Fix `epi_slide_opt` (and related functions) to correctly handle `before=Inf`.
+- Disallow `after=Inf` in slide functions, since it doesn't seem like a likely
+  use case and complicates code.
+
 # epiprocess 0.8
 
 ## Breaking changes

--- a/R/methods-epi_df.R
+++ b/R/methods-epi_df.R
@@ -286,7 +286,12 @@ group_modify.epi_df <- function(.data, .f, ..., .keep = FALSE) {
 #' ) %>%
 #'   as_epi_df(as_of = start_date + 3)
 #' daily_edf %>%
-#'   complete(geo_value, time_value = full_seq(time_value, period = 1), fill = list(value = 0), explicit = FALSE)
+#'   complete(
+#'     geo_value,
+#'     time_value = full_seq(time_value, period = 1),
+#'     fill = list(value = 0),
+#'     explicit = FALSE
+#'   )
 #' # Complete works for weekly data and can take a fill value
 #' # No grouping
 #' weekly_edf <- tibble::tribble(

--- a/R/utils.R
+++ b/R/utils.R
@@ -821,22 +821,22 @@ validate_slide_window_arg <- function(arg, time_type, arg_name = rlang::caller_a
   if (!identical(arg, Inf)) {
     if (time_type == "day") {
       if (!test_int(arg, lower = 0L) && !(inherits(arg, "difftime") && units(arg) == "days")) {
-        cli_abort("Expected `{arg_name}` to be a difftime with units in days or a non-negative integer.")
+        cli_abort("Expected `{arg_name}` to be a difftime with units in days, a non-negative integer, or Inf.")
       }
     } else if (time_type == "week") {
       if (!(inherits(arg, "difftime") && units(arg) == "weeks")) {
-        cli_abort("Expected `{arg_name}` to be a difftime with units in weeks.")
+        cli_abort("Expected `{arg_name}` to be a difftime with units in weeks or Inf.")
       }
     } else if (time_type == "yearmonth") {
       if (!test_int(arg, lower = 0L) || inherits(arg, "difftime")) {
-        cli_abort("Expected `{arg_name}` to be a non-negative integer.")
+        cli_abort("Expected `{arg_name}` to be a non-negative integer or Inf.")
       }
     } else if (time_type == "integer") {
       if (!test_int(arg, lower = 0L) || inherits(arg, "difftime")) {
-        cli_abort("Expected `{arg_name}` to be a non-negative integer.")
+        cli_abort("Expected `{arg_name}` to be a non-negative integer or Inf.")
       }
     } else {
-      cli_abort("Expected `{arg_name}` to be Inf, an appropriate a difftime, or a non-negative integer.")
+      cli_abort("Expected `{arg_name}` to be an appropriate a difftime, a non-negative integer, or Inf.")
     }
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -803,14 +803,13 @@ guess_period.POSIXt <- function(time_values, time_values_arg = rlang::caller_arg
   as.numeric(NextMethod(), units = "secs")
 }
 
-
-validate_slide_window_arg <- function(arg, time_type, arg_name = rlang::caller_arg(arg)) {
+validate_slide_window_arg <- function(arg, time_type, allow_inf = TRUE, arg_name = rlang::caller_arg(arg)) {
   if (is.null(arg)) {
-    cli_abort("`{arg_name}` is a required argument.")
+    cli_abort("`{arg_name}` is a required argument for slide functions.")
   }
 
   if (!checkmate::test_scalar(arg)) {
-    cli_abort("Expected `{arg_name}` to be a scalar value.")
+    cli_abort("Slide function expected `{arg_name}` to be a scalar value.")
   }
 
   if (time_type == "custom") {
@@ -818,25 +817,33 @@ validate_slide_window_arg <- function(arg, time_type, arg_name = rlang::caller_a
     column to a Date, yearmonth, or integer type.")
   }
 
+  msg <- ""
   if (!identical(arg, Inf)) {
     if (time_type == "day") {
       if (!test_int(arg, lower = 0L) && !(inherits(arg, "difftime") && units(arg) == "days")) {
-        cli_abort("Expected `{arg_name}` to be a difftime with units in days, a non-negative integer, or Inf.")
+        msg <- glue::glue_collapse(c("difftime with units in days", "non-negative integer", "Inf"), " or ")
       }
     } else if (time_type == "week") {
       if (!(inherits(arg, "difftime") && units(arg) == "weeks")) {
-        cli_abort("Expected `{arg_name}` to be a difftime with units in weeks or Inf.")
+        msg <- glue::glue_collapse(c("difftime with units in weeks", "Inf"), " or ")
       }
     } else if (time_type == "yearmonth") {
       if (!test_int(arg, lower = 0L) || inherits(arg, "difftime")) {
-        cli_abort("Expected `{arg_name}` to be a non-negative integer or Inf.")
+        msg <- glue::glue_collapse(c("non-negative integer", "Inf"), " or ")
       }
     } else if (time_type == "integer") {
       if (!test_int(arg, lower = 0L) || inherits(arg, "difftime")) {
-        cli_abort("Expected `{arg_name}` to be a non-negative integer or Inf.")
+        msg <- glue::glue_collapse(c("non-negative integer", "Inf"), " or ")
       }
     } else {
-      cli_abort("Expected `{arg_name}` to be an appropriate a difftime, a non-negative integer, or Inf.")
+      msg <- glue::glue_collapse(c("difftime", "non-negative integer", "Inf"), " or ")
     }
+  } else {
+    if (!allow_inf) {
+      msg <- glue::glue_collapse(c("a difftime", "a non-negative integer"), " or ")
+    }
+  }
+  if (msg != "") {
+    cli_abort("Slide function expected `{arg_name}` to be a {msg}.")
   }
 }

--- a/man/complete.epi_df.Rd
+++ b/man/complete.epi_df.Rd
@@ -51,7 +51,12 @@ daily_edf <- tibble::tribble(
 ) \%>\%
   as_epi_df(as_of = start_date + 3)
 daily_edf \%>\%
-  complete(geo_value, time_value = full_seq(time_value, period = 1), fill = list(value = 0), explicit = FALSE)
+  complete(
+    geo_value,
+    time_value = full_seq(time_value, period = 1),
+    fill = list(value = 0),
+    explicit = FALSE
+  )
 # Complete works for weekly data and can take a fill value
 # No grouping
 weekly_edf <- tibble::tribble(

--- a/tests/testthat/test-epi_slide.R
+++ b/tests/testthat/test-epi_slide.R
@@ -107,23 +107,23 @@ test_that("Test errors/warnings for discouraged features", {
 test_that("Both `before` and `after` must be non-NA, non-negative, integer-compatible", {
   expect_error(
     epi_slide(grouped, f, before = -1L, ref_time_values = test_date + 2L),
-    "Expected `before` to be a difftime with units in days or a non-negative integer."
+    "Expected `before` to be a difftime with units in days, a non-negative integer, or Inf."
   )
   expect_error(
     epi_slide(grouped, f, after = -1L, ref_time_values = test_date + 2L),
-    "Expected `after` to be a difftime with units in days or a non-negative integer."
+    "Expected `after` to be a difftime with units in days, a non-negative integer, or Inf."
   )
   expect_error(epi_slide(grouped, f, before = "a", after = days_dt, ref_time_values = test_date + 2L),
-    regexp = "Expected `before` to be a difftime with units in days or a non-negative integer."
+    regexp = "Expected `before` to be a difftime with units in days, a non-negative integer, or Inf."
   )
   expect_error(epi_slide(grouped, f, before = days_dt, after = "a", ref_time_values = test_date + 2L),
-    regexp = "Expected `after` to be a difftime with units in days or a non-negative integer."
+    regexp = "Expected `after` to be a difftime with units in days, a non-negative integer, or Inf."
   )
   expect_error(epi_slide(grouped, f, before = 0.5, after = days_dt, ref_time_values = test_date + 2L),
-    regexp = "Expected `before` to be a difftime with units in days or a non-negative integer."
+    regexp = "Expected `before` to be a difftime with units in days, a non-negative integer, or Inf."
   )
   expect_error(epi_slide(grouped, f, before = days_dt, after = 0.5, ref_time_values = test_date + 2L),
-    regexp = "Expected `after` to be a difftime with units in days or a non-negative integer."
+    regexp = "Expected `after` to be a difftime with units in days, a non-negative integer, or Inf."
   )
   expect_error(
     epi_slide(grouped, f, before = NA, after = 1L, ref_time_values = test_date + 2L),
@@ -136,27 +136,27 @@ test_that("Both `before` and `after` must be non-NA, non-negative, integer-compa
 
   expect_error(
     epi_slide_mean(grouped, col_names = value, before = -1L, ref_time_values = test_date + 2L),
-    "Expected `before` to be a difftime with units in days or a non-negative integer."
+    "Expected `before` to be a difftime with units in days, a non-negative integer, or Inf."
   )
   expect_error(
     epi_slide_mean(grouped, col_names = value, after = -1L, ref_time_values = test_date + 2L),
-    "Expected `after` to be a difftime with units in days or a non-negative integer."
+    "Expected `after` to be a difftime with units in days, a non-negative integer, or Inf."
   )
   expect_error(
     epi_slide_mean(grouped, col_names = value, before = "a", ref_time_values = test_date + 2L),
-    regexp = "Expected `before` to be a difftime with units in days or a non-negative integer."
+    regexp = "Expected `before` to be a difftime with units in days, a non-negative integer, or Inf."
   )
   expect_error(
     epi_slide_mean(grouped, col_names = value, after = "a", ref_time_values = test_date + 2L),
-    regexp = "Expected `after` to be a difftime with units in days or a non-negative integer."
+    regexp = "Expected `after` to be a difftime with units in days, a non-negative integer, or Inf."
   )
   expect_error(
     epi_slide_mean(grouped, col_names = value, before = 0.5, ref_time_values = test_date + 2L),
-    regexp = "Expected `before` to be a difftime with units in days or a non-negative integer."
+    regexp = "Expected `before` to be a difftime with units in days, a non-negative integer, or Inf."
   )
   expect_error(
     epi_slide_mean(grouped, col_names = value, after = 0.5, ref_time_values = test_date + 2L),
-    regexp = "Expected `after` to be a difftime with units in days or a non-negative integer."
+    regexp = "Expected `after` to be a difftime with units in days, a non-negative integer, or Inf."
   )
   expect_error(
     epi_slide_mean(grouped, col_names = value, before = NA, after = days_dt, ref_time_values = test_date + 2L),
@@ -444,7 +444,7 @@ test_that("`ref_time_values` + `all_rows = TRUE` works", {
     ) %>%
       epi_slide_mean(
         value,
-        before = 6 * days_dt, names_sep = NULL, na.rm = TRUE
+        before = 6 * days_dt, na.rm = TRUE
       ),
     basic_mean_result %>%
       rename(slide_value_value = slide_value)

--- a/tests/testthat/test-epi_slide.R
+++ b/tests/testthat/test-epi_slide.R
@@ -52,19 +52,19 @@ basic_mean_result <- tibble::tribble(
 test_that("`before` and `after` are both vectors of length 1", {
   expect_error(
     epi_slide(grouped, f, before = c(0, 1), after = 0, ref_time_values = test_date + 3),
-    "Expected `before` to be a scalar value."
+    "Slide function expected `before` to be a scalar value."
   )
   expect_error(
     epi_slide(grouped, f, before = 1, after = c(0, 1), ref_time_values = test_date + 3),
-    "Expected `after` to be a scalar value."
+    "Slide function expected `after` to be a scalar value."
   )
   expect_error(
     epi_slide_mean(grouped, col_names = value, before = c(0, 1), after = 0, ref_time_values = test_date + 3),
-    "Expected `before` to be a scalar value."
+    "Slide function expected `before` to be a scalar value."
   )
   expect_error(
     epi_slide_mean(grouped, col_names = value, before = 1, after = c(0, 1), ref_time_values = test_date + 3),
-    "Expected `after` to be a scalar value."
+    "Slide function expected `after` to be a scalar value."
   )
 })
 
@@ -107,64 +107,64 @@ test_that("Test errors/warnings for discouraged features", {
 test_that("Both `before` and `after` must be non-NA, non-negative, integer-compatible", {
   expect_error(
     epi_slide(grouped, f, before = -1L, ref_time_values = test_date + 2L),
-    "Expected `before` to be a difftime with units in days, a non-negative integer, or Inf."
+    "Slide function expected `before` to be a difftime with units in days or non-negative integer or Inf."
   )
   expect_error(
     epi_slide(grouped, f, after = -1L, ref_time_values = test_date + 2L),
-    "Expected `after` to be a difftime with units in days, a non-negative integer, or Inf."
+    "Slide function expected `after` to be a difftime with units in days or non-negative integer or Inf."
   )
   expect_error(epi_slide(grouped, f, before = "a", after = days_dt, ref_time_values = test_date + 2L),
-    regexp = "Expected `before` to be a difftime with units in days, a non-negative integer, or Inf."
+    regexp = "Slide function expected `before` to be a difftime with units in days or non-negative integer or Inf."
   )
   expect_error(epi_slide(grouped, f, before = days_dt, after = "a", ref_time_values = test_date + 2L),
-    regexp = "Expected `after` to be a difftime with units in days, a non-negative integer, or Inf."
+    regexp = "Slide function expected `after` to be a difftime with units in days or non-negative integer or Inf."
   )
   expect_error(epi_slide(grouped, f, before = 0.5, after = days_dt, ref_time_values = test_date + 2L),
-    regexp = "Expected `before` to be a difftime with units in days, a non-negative integer, or Inf."
+    regexp = "Slide function expected `before` to be a difftime with units in days or non-negative integer or Inf."
   )
   expect_error(epi_slide(grouped, f, before = days_dt, after = 0.5, ref_time_values = test_date + 2L),
-    regexp = "Expected `after` to be a difftime with units in days, a non-negative integer, or Inf."
+    regexp = "Slide function expected `after` to be a difftime with units in days or non-negative integer or Inf."
   )
   expect_error(
     epi_slide(grouped, f, before = NA, after = 1L, ref_time_values = test_date + 2L),
-    "Expected `before` to be a scalar value."
+    "Slide function expected `before` to be a scalar value."
   )
   expect_error(
     epi_slide(grouped, f, before = days_dt, after = NA, ref_time_values = test_date + 2L),
-    "Expected `after` to be a scalar value."
+    "Slide function expected `after` to be a scalar value."
   )
 
   expect_error(
     epi_slide_mean(grouped, col_names = value, before = -1L, ref_time_values = test_date + 2L),
-    "Expected `before` to be a difftime with units in days, a non-negative integer, or Inf."
+    "Slide function expected `before` to be a difftime with units in days or non-negative integer or Inf."
   )
   expect_error(
     epi_slide_mean(grouped, col_names = value, after = -1L, ref_time_values = test_date + 2L),
-    "Expected `after` to be a difftime with units in days, a non-negative integer, or Inf."
+    "Slide function expected `after` to be a difftime with units in days or non-negative integer or Inf."
   )
   expect_error(
     epi_slide_mean(grouped, col_names = value, before = "a", ref_time_values = test_date + 2L),
-    regexp = "Expected `before` to be a difftime with units in days, a non-negative integer, or Inf."
+    regexp = "Slide function expected `before` to be a difftime with units in days or non-negative integer or Inf."
   )
   expect_error(
     epi_slide_mean(grouped, col_names = value, after = "a", ref_time_values = test_date + 2L),
-    regexp = "Expected `after` to be a difftime with units in days, a non-negative integer, or Inf."
+    regexp = "Slide function expected `after` to be a difftime with units in days or non-negative integer or Inf."
   )
   expect_error(
     epi_slide_mean(grouped, col_names = value, before = 0.5, ref_time_values = test_date + 2L),
-    regexp = "Expected `before` to be a difftime with units in days, a non-negative integer, or Inf."
+    regexp = "Slide function expected `before` to be a difftime with units in days or non-negative integer or Inf."
   )
   expect_error(
     epi_slide_mean(grouped, col_names = value, after = 0.5, ref_time_values = test_date + 2L),
-    regexp = "Expected `after` to be a difftime with units in days, a non-negative integer, or Inf."
+    regexp = "Slide function expected `after` to be a difftime with units in days or non-negative integer or Inf."
   )
   expect_error(
     epi_slide_mean(grouped, col_names = value, before = NA, after = days_dt, ref_time_values = test_date + 2L),
-    "Expected `before` to be a scalar value."
+    "Slide function expected `before` to be a scalar value."
   )
   expect_error(
     epi_slide_mean(grouped, col_names = value, before = days_dt, after = NA, ref_time_values = test_date + 2L),
-    "Expected `after` to be a scalar value."
+    "Slide function expected `after` to be a scalar value."
   )
 
   # Non-integer-class but integer-compatible values are allowed:
@@ -1271,5 +1271,110 @@ test_that("`epi_slide_opt` errors when passed non-`data.table`, non-`slider` fun
       before = days_dt,  ref_time_values = test_date + 1
     ),
     class = "epiprocess__epi_slide_opt__unsupported_slide_function"
+  )
+})
+
+test_that("Inf works in before/after in slide and slide_opt", {
+  # Daily data
+  df <- dplyr::bind_rows(
+    dplyr::tibble(geo_value = "ak", time_value = test_date + 1:200, value = 1:200),
+    dplyr::tibble(geo_value = "al", time_value = test_date + 1:5, value = -(1:5))
+  ) %>%
+    as_epi_df()
+  expect_equal(
+    df %>%
+      group_by(geo_value) %>%
+      epi_slide(
+        before = Inf,
+        slide_value = sum(value)
+      ),
+    df %>%
+      group_by(geo_value) %>%
+      epi_slide(
+        before = 365000,
+        slide_value = sum(value)
+      )
+  )
+  expect_equal(
+    df %>%
+      group_by(geo_value) %>%
+      epi_slide_opt(
+        before = Inf,
+        f = data.table::frollsum,
+        col_names = value
+      ),
+    df %>%
+      group_by(geo_value) %>%
+      epi_slide(
+        before = 365000,
+        slide_value_value = sum(value)
+      )
+  )
+  expect_equal(
+    df %>%
+      group_by(geo_value) %>%
+      epi_slide_opt(
+        before = Inf,
+        f = slider::slide_sum,
+        col_names = value
+      ),
+    df %>%
+      group_by(geo_value) %>%
+      epi_slide(
+        before = 365000,
+        slide_value_value = sum(value)
+      )
+  )
+
+  # Weekly data
+  df <- dplyr::bind_rows(
+    dplyr::tibble(geo_value = "ak", time_value = test_date + 1:200 * 7, value = 1:200),
+    dplyr::tibble(geo_value = "al", time_value = test_date + 1:5 * 7, value = -(1:5))
+  ) %>%
+    as_epi_df()
+
+  expect_equal(
+    df %>%
+      group_by(geo_value) %>%
+      epi_slide(
+        before = Inf,
+        slide_value = sum(value)
+      ),
+    df %>%
+      group_by(geo_value) %>%
+      epi_slide(
+        before = 365000 * weeks_dt,
+        slide_value = sum(value)
+      )
+  )
+  expect_equal(
+    df %>%
+      group_by(geo_value) %>%
+      epi_slide_opt(
+        col_names = value,
+        f = data.table::frollsum,
+        before = Inf
+      ),
+    df %>%
+      group_by(geo_value) %>%
+      epi_slide(
+        before = 365000 * weeks_dt,
+        slide_value_value = sum(value)
+      )
+  )
+  expect_equal(
+    df %>%
+      group_by(geo_value) %>%
+      epi_slide_opt(
+        before = Inf,
+        f = slider::slide_sum,
+        col_names = value
+      ),
+    df %>%
+      group_by(geo_value) %>%
+      epi_slide(
+        before = 365000 * weeks_dt,
+        slide_value_value = sum(value)
+      )
   )
 })

--- a/tests/testthat/test-epix_slide.R
+++ b/tests/testthat/test-epix_slide.R
@@ -169,15 +169,15 @@ test_that("epix_slide works as intended with `as_list_col=TRUE`", {
 test_that("epix_slide `before` validation works", {
   expect_error(
     xx %>% epix_slide(f = ~ sum(.x$binary), before = NA),
-    "Expected `before` to be a scalar value."
+    "Slide function expected `before` to be a scalar value."
   )
   expect_error(
     xx %>% epix_slide(f = ~ sum(.x$binary), before = -1),
-    "Expected `before` to be a difftime with units in days, a non-negative integer, or Inf."
+    "Slide function expected `before` to be a difftime with units in days or non-negative integer or Inf."
   )
   expect_error(
     xx %>% epix_slide(f = ~ sum(.x$binary), before = 1.5),
-    "Expected `before` to be a difftime with units in days, a non-negative integer, or Inf."
+    "Slide function expected `before` to be a difftime with units in days or non-negative integer or Inf."
   )
   # These `before` values should be accepted:
   expect_no_error(xx %>% epix_slide(f = ~ sum(.x$binary), before = 0))
@@ -789,4 +789,17 @@ test_that("`epix_slide` can access objects inside of helper functions", {
   }
   expect_no_error(helper(archive_cases_dv_subset, as.Date("2021-01-01")))
   expect_no_error(helper(xx, 3L))
+})
+
+test_that("`epix_slide` works with before = Inf", {
+  expect_equal(
+    xx %>%
+      group_by(geo_value) %>%
+      epix_slide(sum_binary = sum(binary), before = Inf) %>%
+      pull(sum_binary),
+    xx %>%
+      group_by(geo_value) %>%
+      epix_slide(sum_binary = sum(binary), before = 365000) %>%
+      pull(sum_binary)
+  )
 })

--- a/tests/testthat/test-epix_slide.R
+++ b/tests/testthat/test-epix_slide.R
@@ -173,11 +173,11 @@ test_that("epix_slide `before` validation works", {
   )
   expect_error(
     xx %>% epix_slide(f = ~ sum(.x$binary), before = -1),
-    "Expected `before` to be a difftime with units in days or a non-negative integer."
+    "Expected `before` to be a difftime with units in days, a non-negative integer, or Inf."
   )
   expect_error(
     xx %>% epix_slide(f = ~ sum(.x$binary), before = 1.5),
-    "Expected `before` to be a difftime with units in days or a non-negative integer."
+    "Expected `before` to be a difftime with units in days, a non-negative integer, or Inf."
   )
   # These `before` values should be accepted:
   expect_no_error(xx %>% epix_slide(f = ~ sum(.x$binary), before = 0))


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current main reviewers:
      brookslogan, nmdefries.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).
- See [DEVELOPMENT.md](DEVELOPMENT.md) for more information on the development
  process.

### Change explanations for reviewer

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #503