### PR TITLE
Fix validate_version_bound typo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: epiprocess
 Title: Tools for basic signal processing in epidemiology
-Version: 0.9.0
+Version: 0.10.0
 Authors@R: c(
     person("Jacob", "Bien", role = "ctb"),
     person("Logan", "Brooks", , "lcbrooks@andrew.cmu.edu", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: epiprocess
 Title: Tools for basic signal processing in epidemiology
-Version: 0.10.0
+Version: 0.9.1
 Authors@R: c(
     person("Jacob", "Bien", role = "ctb"),
     person("Logan", "Brooks", , "lcbrooks@andrew.cmu.edu", role = c("aut", "cre")),

--- a/R/archive.R
+++ b/R/archive.R
@@ -25,7 +25,7 @@
 #' @noRd
 validate_version_bound <- function(version_bound, x, na_ok = FALSE,
                                    version_bound_arg = rlang::caller_arg(version_bound),
-                                   x_arg = rlang::caller_arg(version_bound)) {
+                                   x_arg = rlang::caller_arg(x)) {
   if (is.null(version_bound)) {
     cli_abort(
       "{version_bound_arg} cannot be NULL",


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [-] Request a review from one of the current main reviewers:
      brookslogan, nmdefries.
- [x] Make sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [-] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).
- See [DEVELOPMENT.md](DEVELOPMENT.md) for more information on the development
  process.

### Change explanations for reviewer

This fixes a typo that appears to have no impact, but might confuse us in the future.  The impacted `x_arg` never actually seems to be used, so maybe something else should be done but I'm not looking too much into it.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #{issue number}
