### PR TITLE
docs(complete.epi_df): fix backticks, tweak 1-line summary

### DIFF
--- a/R/methods-epi_df.R
+++ b/R/methods-epi_df.R
@@ -256,7 +256,7 @@ group_modify.epi_df <- function(.data, .f, ..., .keep = FALSE) {
   dplyr::dplyr_reconstruct(NextMethod(), .data)
 }
 
-#' Complete an `epi_df` with additional rows for missing key combinations
+#' "Complete" an `epi_df`, adding missing rows and/or replacing `NA`s
 #'
 #' A `tidyr::complete()` analogue for `epi_df` objects. This function
 #' can be used, for example, to add rows for missing combinations

--- a/R/methods-epi_df.R
+++ b/R/methods-epi_df.R
@@ -256,9 +256,9 @@ group_modify.epi_df <- function(.data, .f, ..., .keep = FALSE) {
   dplyr::dplyr_reconstruct(NextMethod(), .data)
 }
 
-#' Complete epi_df
+#' Complete an `epi_df` with additional rows for missing key combinations
 #'
-#' A `tidyr::complete()` analogue for `epi_df`` objects. This function
+#' A `tidyr::complete()` analogue for `epi_df` objects. This function
 #' can be used, for example, to add rows for missing combinations
 #' of `geo_value` and `time_value`, filling other columns with `NA`s.
 #' See the examples for usage details.

--- a/man/complete.epi_df.Rd
+++ b/man/complete.epi_df.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/methods-epi_df.R
 \name{complete.epi_df}
 \alias{complete.epi_df}
-\title{Complete an \code{epi_df} with additional rows for missing key combinations}
+\title{"Complete" an \code{epi_df}, adding missing rows and/or replacing \code{NA}s}
 \usage{
 \method{complete}{epi_df}(data, ..., fill = list(), explicit = TRUE)
 }

--- a/man/complete.epi_df.Rd
+++ b/man/complete.epi_df.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/methods-epi_df.R
 \name{complete.epi_df}
 \alias{complete.epi_df}
-\title{Complete epi_df}
+\title{Complete an \code{epi_df} with additional rows for missing key combinations}
 \usage{
 \method{complete}{epi_df}(data, ..., fill = list(), explicit = TRUE)
 }
@@ -16,7 +16,9 @@
 \item{explicit}{see \code{\link[tidyr:complete]{tidyr::complete}}}
 }
 \description{
-A \code{tidyr::complete()} analogue for \verb{epi_df`` objects. This function can be used, for example, to add rows for missing combinations of }geo_value\code{and}time_value\verb{, filling other columns with }NA`s.
+A \code{tidyr::complete()} analogue for \code{epi_df} objects. This function
+can be used, for example, to add rows for missing combinations
+of \code{geo_value} and \code{time_value}, filling other columns with \code{NA}s.
 See the examples for usage details.
 }
 \examples{


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [-] Request a review from one of the current main reviewers:
      brookslogan, nmdefries.
- [-] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [-] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).
- See [DEVELOPMENT.md](DEVELOPMENT.md) for more information on the development
  process.

### Change explanations for reviewer

- @XuedaShen  noticed an issues with the code formatting.

![2024-10-24-154754_766x86_scrot](https://github.com/user-attachments/assets/00c4ab58-9e48-4812-84f5-6b4dddf6e90a)

This fixes that + tweaks the summary.  Don't think it's worth version bump or news entry given all the other doc changes.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

