### PR TITLE
Improve `epi_slide_{sum,mean}` unsupported-arg messages.

### DIFF
--- a/R/slide.R
+++ b/R/slide.R
@@ -1010,8 +1010,9 @@ epi_slide_mean <- function(
   }
   if ("new_col_name" %in% provided_args || ".new_col_name" %in% provided_args) {
     cli::cli_abort(
-      "epi_slide_mean: the argument `new_col_name` is not supported. If you want to customize
-      the output column names, use `dplyr::rename` after the slide."
+      "epi_slide_opt: the argument `new_col_name` is not supported for `epi_slide_opt`. If you want to customize
+      the output column names, use `.prefix =`, `.suffix =`, or `.new_col_**names** =`.",
+      class = "epiprocess__epi_slide_opt__new_name_not_supported"
     )
   }
   if ("names_sep" %in% provided_args || ".names_sep" %in% provided_args) {
@@ -1069,8 +1070,9 @@ epi_slide_sum <- function(
   }
   if ("new_col_name" %in% provided_args || ".new_col_name" %in% provided_args) {
     cli::cli_abort(
-      "epi_slide_sum: the argument `new_col_name` is not supported. If you want to customize
-      the output column names, use `dplyr::rename` after the slide."
+      "epi_slide_opt: the argument `new_col_name` is not supported for `epi_slide_opt`. If you want to customize
+      the output column names, use `.prefix =`, `.suffix =`, or `.new_col_**names** =`.",
+      class = "epiprocess__epi_slide_opt__new_name_not_supported"
     )
   }
   if ("names_sep" %in% provided_args || ".names_sep" %in% provided_args) {

--- a/man/epiprocess-package.Rd
+++ b/man/epiprocess-package.Rd
@@ -16,12 +16,13 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Logan Brooks \email{lcbrooks@andrew.cmu.edu}
+\strong{Maintainer}: Logan Brooks \email{lcbrooks+github@andrew.cmu.edu}
 
 Authors:
 \itemize{
   \item Daniel McDonald
   \item Evan Ray
+  \item Dmitry Shemetov
   \item Ryan Tibshirani
 }
 
@@ -34,7 +35,7 @@ Other contributors:
   \item Ken Mawer [contributor]
   \item Chloe You [contributor]
   \item Quang Nguyen [contributor]
-  \item Dmitry Shemetov [contributor]
+  \item David Weber \email{davidweb@andrew.cmu.edu} [contributor]
   \item Lionel Henry (Author of included rlang fragments) [contributor]
   \item Hadley Wickham (Author of included rlang fragments) [contributor]
   \item Posit (Copyright holder of included rlang fragments) [copyright holder]


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [-] Request a review from one of the current main reviewers:
      brookslogan, nmdefries.
- [-] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
  - Skipping bumping as this is so near 0.10.0 release PRs.
- [-] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).
   - should already be covered by the the `epi_slide_opt` change description
- See [DEVELOPMENT.md](DEVELOPMENT.md) for more information on the development
  process.

### Change explanations for reviewer
- Also fixes lack of `document()` from accidental direct push.  Branch protection settings have been updated to try to prevent.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #580 
