### PR TITLE
Change as-of date in vignette example to match new `epidatasets::covid_case_death_rates_extended` as-of date

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: epiprocess
 Title: Tools for basic signal processing in epidemiology
-Version: 0.10.4
+Version: 0.10.5
 Authors@R: c(
     person("Jacob", "Bien", role = "ctb"),
     person("Logan", "Brooks", , "lcbrooks+github@andrew.cmu.edu", role = c("aut", "cre")),

--- a/vignettes/correlation.Rmd
+++ b/vignettes/correlation.Rmd
@@ -36,7 +36,7 @@ The data can also be fetched from the Delphi Epidata API with the following quer
 ```{r, eval = FALSE}
 library(epidatr)
 
-d <- as.Date("2024-03-20")
+d <- as.Date("2023-03-10")
 
 x <- pub_covidcast(
   source = "jhu-csse",


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [ ] Request a review from one of the current main reviewers:
      brookslogan, nmdefries.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [ ] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).
- See [DEVELOPMENT.md](DEVELOPMENT.md) for more information on the development
  process.

### Change explanations for reviewer

Accompanies https://github.com/cmu-delphi/epidatasets/pull/16

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #{issue number}
