### PR TITLE
Address `dist_quantiles()` deprecation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: epiprocess
 Title: Tools for basic signal processing in epidemiology
-Version: 0.11.0
+Version: 0.11.1
 Authors@R: c(
     person("Jacob", "Bien", role = "ctb"),
     person("Logan", "Brooks", , "lcbrooks+github@andrew.cmu.edu", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,12 +66,13 @@ Suggests:
     distributional,
     epidatr,
     epipredict,
+    hardhat,
     here,
     knitr,
     outbreaks,
     readr,
     rmarkdown,
-    testthat (>= 3.1.5),
+    testthat,
     trendfilter,
     withr
 VignetteBuilder:

--- a/R/key_colnames.R
+++ b/R/key_colnames.R
@@ -91,8 +91,8 @@ key_colnames.epi_df <- function(x, ...,
   if (!identical(other_keys, expected_other_keys)) {
     cli_abort(c(
       "The provided `other_keys` argument didn't match the `other_keys` of `x`",
-      "*" = "`other_keys` was {format_chr_with_quotes(other_keys)}",
-      "*" = "`expected_other_keys` was {format_chr_with_quotes(expected_other_keys)}",
+      "*" = "`other_keys` was {format_chr_deparse(other_keys)}",
+      "*" = "`expected_other_keys` was {format_chr_deparse(expected_other_keys)}",
       "i" = "If you know that `x` will always be an `epi_df` and
              resolve this discrepancy by adjusting the metadata of `x`, you
              shouldn't have to pass `other_keys =` here anymore,

--- a/R/methods-epi_archive.R
+++ b/R/methods-epi_archive.R
@@ -450,7 +450,8 @@ epix_merge <- function(x, y,
   y_nonby_colnames <- setdiff(names(y_dt), by)
   if (length(intersect(x_nonby_colnames, y_nonby_colnames)) != 0L) {
     cli_abort("
-            `x` and `y` DTs have overlapping non-by column names;
+            `x` and `y` DTs both have measurement columns named
+            {format_chr_with_quotes(intersect(x_nonby_colnames, y_nonby_colnames))};
             this is currently not supported; please manually fix up first:
             any overlapping columns that can are key-like should be
             incorporated into the key, and other columns should be renamed.

--- a/R/utils.R
+++ b/R/utils.R
@@ -111,9 +111,9 @@ format_chr_deparse <- function(x) {
 #' @examples
 #' cli::cli_inform('{format_chr_with_quotes("x")}')
 #' cli::cli_inform('{format_chr_with_quotes(c("x","y"))}')
-#' nms <- c("x","\"Total Cases\"")
-#' cli::cli_inform('{format_chr_with_quotes(nms)}')
-#' cli::cli_inform('{format_chr_with_quotes(character())}')
+#' nms <- c("x", "\"Total Cases\"")
+#' cli::cli_inform("{format_chr_with_quotes(nms)}")
+#' cli::cli_inform("{format_chr_with_quotes(character())}")
 #'
 #' @keywords internal
 format_chr_with_quotes <- function(x, empty = "*none*") {

--- a/R/utils.R
+++ b/R/utils.R
@@ -109,11 +109,11 @@ format_chr_deparse <- function(x) {
 #' @return chr; same `length` as `x` if `x` had nonzero length; value of `empty` otherwise
 #'
 #' @examples
-#' cli::cli_inform('{format_chr_with_quotes("x")}')
-#' cli::cli_inform('{format_chr_with_quotes(c("x","y"))}')
+#' cli::cli_inform('{epiprocess:::format_chr_with_quotes("x")}')
+#' cli::cli_inform('{epiprocess:::format_chr_with_quotes(c("x","y"))}')
 #' nms <- c("x", "\"Total Cases\"")
-#' cli::cli_inform("{format_chr_with_quotes(nms)}")
-#' cli::cli_inform("{format_chr_with_quotes(character())}")
+#' cli::cli_inform("{epiprocess:::format_chr_with_quotes(nms)}")
+#' cli::cli_inform("{epiprocess:::format_chr_with_quotes(character())}")
 #'
 #' @keywords internal
 format_chr_with_quotes <- function(x, empty = "*none*") {

--- a/R/utils.R
+++ b/R/utils.R
@@ -98,26 +98,29 @@ format_chr_deparse <- function(x) {
   paste(collapse = "", deparse(x))
 }
 
-#' Format a character vector as a string via deparsing/quoting each
+#' Format each entry in a character vector via quoting; special replacement for length 0
 #'
-#' @param x `chr`; e.g., `colnames` of some data frame
-#' @param empty string; what should be output if `x` is of length 0?
-#' @return string
+#' Performs no escaping within the strings; if you want something that reader
+#' could copy-paste to debug, look into `format_deparse` (note that this
+#' collapses into a single string).
+#'
+#' @param x chr; e.g., `colnames` of some data frame
+#' @param empty chr, likely string; what should be output if `x` is of length 0?
+#' @return chr; same `length` as `x` if `x` had nonzero length; value of `empty` otherwise
+#'
+#' @examples
+#' cli::cli_inform('{format_chr_with_quotes("x")}')
+#' cli::cli_inform('{format_chr_with_quotes(c("x","y"))}')
+#' nms <- c("x","\"Total Cases\"")
+#' cli::cli_inform('{format_chr_with_quotes(nms)}')
+#' cli::cli_inform('{format_chr_with_quotes(character())}')
+#'
 #' @keywords internal
 format_chr_with_quotes <- function(x, empty = "*none*") {
   if (length(x) == 0L) {
     empty
   } else {
-    # Deparse to get quoted + escape-sequenced versions of varnames; collapse to
-    # single line (assuming no newlines in `x`). Though if we hand this to cli
-    # it may insert them (even in middle of quotes) while wrapping lines.
-    deparsed_collapsed <- paste(collapse = "", deparse(x))
-    if (length(x) == 1L) {
-      deparsed_collapsed
-    } else {
-      # remove surrounding `c()`:
-      substr(deparsed_collapsed, 3L, nchar(deparsed_collapsed) - 1L)
-    }
+    paste0('"', x, '"')
   }
 }
 

--- a/man/format_chr_with_quotes.Rd
+++ b/man/format_chr_with_quotes.Rd
@@ -2,19 +2,29 @@
 % Please edit documentation in R/utils.R
 \name{format_chr_with_quotes}
 \alias{format_chr_with_quotes}
-\title{Format a character vector as a string via deparsing/quoting each}
+\title{Format each entry in a character vector via quoting; special replacement for length 0}
 \usage{
 format_chr_with_quotes(x, empty = "*none*")
 }
 \arguments{
-\item{x}{\code{chr}; e.g., \code{colnames} of some data frame}
+\item{x}{chr; e.g., \code{colnames} of some data frame}
 
-\item{empty}{string; what should be output if \code{x} is of length 0?}
+\item{empty}{chr, likely string; what should be output if \code{x} is of length 0?}
 }
 \value{
-string
+chr; same \code{length} as \code{x} if \code{x} had nonzero length; value of \code{empty} otherwise
 }
 \description{
-Format a character vector as a string via deparsing/quoting each
+Performs no escaping within the strings; if you want something that reader
+could copy-paste to debug, look into \code{format_deparse} (note that this
+collapses into a single string).
+}
+\examples{
+cli::cli_inform('{format_chr_with_quotes("x")}')
+cli::cli_inform('{format_chr_with_quotes(c("x","y"))}')
+nms <- c("x","\"Total Cases\"")
+cli::cli_inform('{format_chr_with_quotes(nms)}')
+cli::cli_inform('{format_chr_with_quotes(character())}')
+
 }
 \keyword{internal}

--- a/man/format_chr_with_quotes.Rd
+++ b/man/format_chr_with_quotes.Rd
@@ -22,9 +22,9 @@ collapses into a single string).
 \examples{
 cli::cli_inform('{format_chr_with_quotes("x")}')
 cli::cli_inform('{format_chr_with_quotes(c("x","y"))}')
-nms <- c("x","\"Total Cases\"")
-cli::cli_inform('{format_chr_with_quotes(nms)}')
-cli::cli_inform('{format_chr_with_quotes(character())}')
+nms <- c("x", "\"Total Cases\"")
+cli::cli_inform("{format_chr_with_quotes(nms)}")
+cli::cli_inform("{format_chr_with_quotes(character())}")
 
 }
 \keyword{internal}

--- a/man/format_chr_with_quotes.Rd
+++ b/man/format_chr_with_quotes.Rd
@@ -20,11 +20,11 @@ could copy-paste to debug, look into \code{format_deparse} (note that this
 collapses into a single string).
 }
 \examples{
-cli::cli_inform('{format_chr_with_quotes("x")}')
-cli::cli_inform('{format_chr_with_quotes(c("x","y"))}')
+cli::cli_inform('{epiprocess:::format_chr_with_quotes("x")}')
+cli::cli_inform('{epiprocess:::format_chr_with_quotes(c("x","y"))}')
 nms <- c("x", "\"Total Cases\"")
-cli::cli_inform("{format_chr_with_quotes(nms)}")
-cli::cli_inform("{format_chr_with_quotes(character())}")
+cli::cli_inform("{epiprocess:::format_chr_with_quotes(nms)}")
+cli::cli_inform("{epiprocess:::format_chr_with_quotes(character())}")
 
 }
 \keyword{internal}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,6 @@
 library(testthat)
 library(epiprocess)
 
+stopifnot(packageVersion("testthat") >= "3.1.5")
+
 test_check("epiprocess")

--- a/tests/testthat/test-compactify.R
+++ b/tests/testthat/test-compactify.R
@@ -134,7 +134,7 @@ test_that("compactify works on distributions", {
     .pred_distn = c(
       quantile_pred_once(c(1, 5, 9), c(0.1, 0.5, 0.9)),
       quantile_pred_once(c(1, NA, 9), c(0.1, 0.5, 0.9)), # single NA in quantiles
-      quantile_pred_once(c(NA, NA, NA), c(0.1, 0.5, 0.9)), # all NAs in quantiles (hardhat+vctrs+epipredict treats as missing)
+      quantile_pred_once(c(NA, NA, NA), c(0.1, 0.5, 0.9)), # all NAs in quantiles
       quantile_pred_once(c(1, 5, 9), c(0.1, 0.5, 0.9)), # and back
       quantile_pred_once(c(3, 5, 9), c(0.1, 0.5, 0.9)), # change quantile
       quantile_pred_once(c(3, 5, 9), c(0.1, 0.5, 0.9)) # LOCF

--- a/tests/testthat/test-epix_merge.R
+++ b/tests/testthat/test-epix_merge.R
@@ -175,7 +175,7 @@ test_that("epix_merge forbids and warns on metadata and naming issues", {
       as_epi_archive(tibble::tibble(geo_value = "ak", time_value = test_date, version = test_date + 1L, value = 1L)),
       as_epi_archive(tibble::tibble(geo_value = "ak", time_value = test_date, version = test_date + 1L, value = 2L))
     ),
-    regexp = "overlapping.*names"
+    regexp = 'both have measurement columns named "value"'
   )
 })
 


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current main reviewers:
      brookslogan, nmdefries.
- [x] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [-] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).
  - don't think this is worth a NEWS entry.
- See [DEVELOPMENT.md](DEVELOPMENT.md) for more information on the development
  process.

### Change explanations for reviewer

- See #631 for context.  epipredict updated to use `hardhat::quantile_pred()` rather than its own `dist_quantiles()` backed by `{distributional}`.  It has some extra constraints and a bug, and epipredict adds onto the bugs.  Current main goal is to avoid CHECK noise in unrelated PRs.
- Adjusts some formatting utilities that were producing bad error messages along the way.
- Adjusts existing forecast archive test to use `hardhat::quantile_pred()`, but also skips it as we need something in #611 or hardhat/epipredict fix to address current `is_locf` approach using `dplyr::lag` with triggers the hardhat+epipredict issue.
- Adds another forecast archive test which fails even with #611 and requires the hardhat fix, and thus also skips it for now.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Closes #631.