### PR TITLE
perf: fix temp key in filter.epi_archive that has to be reset

### DIFF
--- a/R/methods-epi_archive.R
+++ b/R/methods-epi_archive.R
@@ -1159,7 +1159,7 @@ filter.epi_archive <- function(.data, ..., .by = NULL, .format_aware = FALSE) {
   out_other_keys <- .data$other_keys
   # `filter` makes no guarantees about not aliasing columns in its result when
   # the filter condition is all TRUE, so don't setDT.
-  out_dtbl <- as.data.table(out_tbl, key = out_other_keys)
+  out_dtbl <- as.data.table(out_tbl, key = c("geo_value", "time_value", out_other_keys, "version"))
   result <- new_epi_archive(
     out_dtbl,
     out_geo_type, out_time_type, out_other_keys,


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [x] Request a review from one of the current main reviewers:
      brookslogan, nmdefries.
- [ ] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [ ] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).
- [ ] Styling and documentation checks. Make a PR comment with:
  - `/document` to check the package documentation and fix any issues.
  - `/style` to check the style and fix any issues.
  - `/preview-docs` to preview the docs.
  - See Actions GitHub tab to track progress of these commands.
- See [DEVELOPMENT.md](DEVELOPMENT.md) for more information on the development
  process.

### Change explanations for reviewer

`filter.epi_archive` sets a `data.table`'s key before feeding it into `new_epi_archive`, thinking that / planning for `new_epi_archive` to require the key to already be set properly.  But it did it improperly.  Thankfully, `new_epi_archive` actually just does a second round of sorting if required.  There are some warnings in some versions of `data.table` in some cases from the bogus intermediate key.

The archive key ordering is still a bit weird... I thought I already completed most of the geo-time-other[-version] --> geo-other-time[-version] changes, but apparently not.  Not adjusting this now because example data sets need checked.

Don't think this is worth a version bump or changelog entry.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #{issue number}
