### PR TITLE
Fix `autoplot.epi_archive` on archives with a `v` column

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: epiprocess
 Title: Tools for basic signal processing in epidemiology
-Version: 0.12.0
+Version: 0.12.0.9999
 Authors@R: c(
     person("Jacob", "Bien", role = "ctb"),
     person("Logan", "Brooks", , "lcbrooks+github@andrew.cmu.edu", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 # epiprocess
 
-Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.x.y will indicate PR's.
+Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.x.0.9999 will
+indicate development versions beyond 0.x.
+
+# epiprocess 0.12.0.9999
+
+## Bug fixes
+- `autoplot.epi_archive` now works properly on archives that contain a column
+  named `v` (#674, thanks to @pcollender for the report).
 
 # epiprocess 0.12
 

--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -311,7 +311,7 @@ autoplot.epi_archive <- function(object, ...,
   snapshots <- purrr::map(
     .versions,
     function(v) {
-      dplyr::mutate(epix_as_of(object, v), version = v)
+      dplyr::mutate(epix_as_of(object, v), version = .env$v)
     }
   ) %>%
     purrr::list_rbind() %>%


### PR DESCRIPTION
### Checklist

Please:

- [ ] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [ ] Request a review from one of the current main reviewers:
      brookslogan, nmdefries.
- [ ] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [ ] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).
- [ ] Styling and documentation checks. Make a PR comment with:
  - `/style` to check the style and fix any issues.
  - `/document` to check the package documentation and fix any issues.
  - `/preview-docs` to preview the docs.
  - See Actions GitHub tab to track progress of these commands.
- See [DEVELOPMENT.md](DEVELOPMENT.md) for more information on the development
  process.

### Change explanations for reviewer
- Uses `.env$v` to avoid using `v` column.
- Also changing to a .9999 dev version numbering scheme.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch
- Resolves #674.
