### PR TITLE
Map `reference_time` and `report_time` columns to `time_value` and `version` / `as_of` 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ indicate development versions beyond 0.x.
 # epiprocess 0.12.0.9999
 
 ## New features
+- `as_epi_df()` and `as_epi_archive()` now recognize `reference_time` and `report_time` columns, mapping them to `time_value` and `version` / `as_of` respectively.
 - `revision_summary()` now detects bulk reporting adding new time
   values, and excludes bulk reporting for some statistics.
 - Added `linelist_to_archive()`, which converts a linelist or chart of patient data updates into an `epi_archive`.

--- a/R/epi_df.R
+++ b/R/epi_df.R
@@ -293,17 +293,17 @@ as_epi_df.tbl_df <- function(
         "as_of" %in% names(attributes(x)$metadata)
     ) {
       as_of <- attributes(x)$metadata$as_of
-    } else if ("as_of" %in% names(x)) {
-      # Next check for as_of, issue, or version columns
-      as_of <- max(x$as_of)
-    } else if ("issue" %in% names(x)) {
-      as_of <- max(x$issue)
-    } else if ("version" %in% names(x)) {
-      as_of <- max(x$version)
     } else {
-      # If we got here then we failed
-      as_of <- Sys.time()
-    } # Use the current day-time
+      # Guessing as_of from version columns
+      candidates <- vctrs::vec_set_intersect(version_column_names(), names(x))
+
+      if (length(candidates) > 0) {
+        as_of <- max(x[[candidates[[1]]]])
+      } else {
+        # If we got here then we failed
+        as_of <- Sys.time()
+      }
+    }
   }
 
   assert_character(other_keys)

--- a/R/utils.R
+++ b/R/utils.R
@@ -678,7 +678,8 @@ time_column_names <- function() {
   substitutions <- c(
     "time_value", "date", "time", "datetime", "dateTime", "date_time", "target_date",
     "week", "epiweek", "month", "mon", "year", "yearmon", "yearmonth",
-    "yearMon", "yearMonth", "dates", "time_values", "target_dates", "time_Value"
+    "yearMon", "yearMonth", "dates", "time_values", "target_dates", "time_Value",
+    "reference_time", "reference_date", "ref_time", "ref_date", "event_date", "onset_date"
   )
   substitutions <- upcase_snake_case(substitutions)
   names(substitutions) <- rep("time_value", length(substitutions))
@@ -695,7 +696,8 @@ geo_column_names <- function() {
   substitutions <- c(
     "geo_value", "geo_values", "geo_id", "geos", "location", "jurisdiction", "fips", "zip",
     "county", "hrr", "msa", "state", "province", "nation", "states",
-    "provinces", "counties", "geo_Value"
+    "provinces", "counties", "geo_Value", "region", "regions", "country", "countries",
+    "state_code", "fips_code", "zip_code", "location_id", "location_code"
   )
   substitutions <- upcase_snake_case(substitutions)
   names(substitutions) <- rep("geo_value", length(substitutions))
@@ -710,9 +712,12 @@ geo_column_names <- function() {
 #' @keywords internal
 version_column_names <- function() {
   substitutions <- c(
-    "version", "issue", "release",
+    "version", "issue", "issues", "release",
     "version_recorded", "report_date", "recorded_date",
-    "issue_date", "release_date", "as_of", "revision"
+    "issue_date", "release_date", "as_of", "revision",
+    "report_time", "update_date", "update_time", "publish_date",
+    "publish_time", "published_date", "published_time",
+    "upload_date", "upload_time", "as_of_date", "as_of_time", "asof"
   )
   substitutions <- upcase_snake_case(substitutions)
   names(substitutions) <- rep("version", length(substitutions))

--- a/man/geo_column_names.Rd
+++ b/man/geo_column_names.Rd
@@ -8,6 +8,6 @@ geo_column_names()
 }
 \description{
 the full list of potential substitutions for the \code{geo_value} column name:
-geo_value, geo_values, geo_id, geos, location, jurisdiction, fips, zip, county, hrr, msa, state, province, nation, states, provinces, counties, geo_Value, Geo_Value, Geo_Values, Geo_Id, Geos, Location, Jurisdiction, Fips, Zip, County, Hrr, Msa, State, Province, Nation, States, Provinces, Counties, Geo_Value
+geo_value, geo_values, geo_id, geos, location, jurisdiction, fips, zip, county, hrr, msa, state, province, nation, states, provinces, counties, geo_Value, region, regions, country, countries, state_code, fips_code, zip_code, location_id, location_code, Geo_Value, Geo_Values, Geo_Id, Geos, Location, Jurisdiction, Fips, Zip, County, Hrr, Msa, State, Province, Nation, States, Provinces, Counties, Geo_Value, Region, Regions, Country, Countries, State_Code, Fips_Code, Zip_Code, Location_Id, Location_Code
 }
 \keyword{internal}

--- a/man/time_column_names.Rd
+++ b/man/time_column_names.Rd
@@ -8,6 +8,6 @@ time_column_names()
 }
 \description{
 the full list of potential substitutions for the \code{time_value} column name:
-time_value, date, time, datetime, dateTime, date_time, target_date, week, epiweek, month, mon, year, yearmon, yearmonth, yearMon, yearMonth, dates, time_values, target_dates, time_Value, Time_Value, Date, Time, Datetime, DateTime, Date_Time, Target_Date, Week, Epiweek, Month, Mon, Year, Yearmon, Yearmonth, YearMon, YearMonth, Dates, Time_Values, Target_Dates, Time_Value
+time_value, date, time, datetime, dateTime, date_time, target_date, week, epiweek, month, mon, year, yearmon, yearmonth, yearMon, yearMonth, dates, time_values, target_dates, time_Value, reference_time, reference_date, ref_time, ref_date, event_date, onset_date, Time_Value, Date, Time, Datetime, DateTime, Date_Time, Target_Date, Week, Epiweek, Month, Mon, Year, Yearmon, Yearmonth, YearMon, YearMonth, Dates, Time_Values, Target_Dates, Time_Value, Reference_Time, Reference_Date, Ref_Time, Ref_Date, Event_Date, Onset_Date
 }
 \keyword{internal}

--- a/man/version_column_names.Rd
+++ b/man/version_column_names.Rd
@@ -8,6 +8,6 @@ version_column_names()
 }
 \description{
 the full list of potential substitutions for the \code{version} column name:
-version, issue, release, version_recorded, report_date, recorded_date, issue_date, release_date, as_of, revision, Version, Issue, Release, Version_Recorded, Report_Date, Recorded_Date, Issue_Date, Release_Date, As_Of, Revision
+version, issue, issues, release, version_recorded, report_date, recorded_date, issue_date, release_date, as_of, revision, report_time, update_date, update_time, publish_date, publish_time, published_date, published_time, upload_date, upload_time, as_of_date, as_of_time, asof, Version, Issue, Issues, Release, Version_Recorded, Report_Date, Recorded_Date, Issue_Date, Release_Date, As_Of, Revision, Report_Time, Update_Date, Update_Time, Publish_Date, Publish_Time, Published_Date, Published_Time, Upload_Date, Upload_Time, As_Of_Date, As_Of_Time, Asof
 }
 \keyword{internal}

--- a/tests/testthat/test-archive.R
+++ b/tests/testthat/test-archive.R
@@ -222,3 +222,32 @@ test_that("is_locf works as expected", {
   is_repeated <- c(0, 1, 0, 1, 0, 1, 1, 1)
   expect_equal(is_locf(vec, .Machine$double.eps^0.5, FALSE), as.logical(is_repeated))
 })
+
+test_that("as_epi_archive guesses reference_time and report_time correctly", {
+  df <- data.frame(
+    geo_value = "ca",
+    reference_time = as.Date("2020-01-01") + 0:19,
+    report_time = as.Date("2020-01-02") + 0:19,
+    value = 1:20
+  )
+  expect_message(
+    expect_no_error(ea <- as_epi_archive(df, compactify = FALSE)),
+    class = "epiprocess__guess_column_inferring_inform"
+  )
+  expect_equal(ea$DT$time_value, df$reference_time)
+  expect_equal(ea$DT$version, df$report_time)
+
+  df2 <- data.frame(
+    country = "ca",
+    ref_time = as.Date("2020-01-01") + 0:19,
+    publish_date = as.Date("2020-01-02") + 0:19,
+    value = 1:20
+  )
+  expect_message(
+    expect_no_error(ea2 <- as_epi_archive(df2, compactify = FALSE)),
+    class = "epiprocess__guess_column_inferring_inform"
+  )
+  expect_equal(ea2$DT$geo_value, df2$country)
+  expect_equal(ea2$DT$time_value, df2$ref_time)
+  expect_equal(ea2$DT$version, df2$publish_date)
+})

--- a/tests/testthat/test-epi_df.R
+++ b/tests/testthat/test-epi_df.R
@@ -87,6 +87,20 @@ test_that("as_epi_df works for nonstandard input", {
   expect_error(tib_epi_df <- tib %>% as_epi_df(),
     class = "epiprocess__guess_column__multiple_substitution_error"
   )
+
+  # Test guessing of reference_time and report_time columns
+  tib_ref <- tibble::tibble(
+    x = 1:10,
+    reference_time = rep(seq(as.Date("2020-01-01"), by = 1, length.out = 5), times = 2),
+    geo_value = rep(c("ca", "hi"), each = 5),
+    report_time = rep(as.Date("2020-01-06"), 10)
+  )
+  expect_message(
+    expect_no_error(tib_ref_epi_df <- tib_ref %>% as_epi_df()),
+    class = "epiprocess__guess_column_inferring_inform"
+  )
+  expect_identical(tib_ref_epi_df$time_value, tib_ref$reference_time)
+  expect_identical(attributes(tib_ref_epi_df)$metadata$as_of, as.Date("2020-01-06"))
 })
 
 test_that("as_epi_df ungroups", {


### PR DESCRIPTION
### Checklist

Please:

- [X] Make sure this PR is against "dev", not "main" (unless this is a release
      PR).
- [X] Request a review from one of the current main reviewers:
      brookslogan, nmdefries.
- [ ] Makes sure to bump the version number in `DESCRIPTION`. Always increment
      the patch version number (the third number), unless you are making a
      release PR from dev to main, in which case increment the minor version
      number (the second number).
- [X] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      1.7.2, then write your changes under the 1.8 heading).
- [ ] Styling and documentation checks. Make a PR comment with:
  - `/style` to check the style and fix any issues.
  - `/document` to check the package documentation and fix any issues.
  - `/preview-docs` to preview the docs.
  - See Actions GitHub tab to track progress of these commands.
- See [DEVELOPMENT.md](DEVELOPMENT.md) for more information on the development
  process.

### Change explanations for reviewer

This update allows `as_epi_df()` and `as_epi_archive()` to recognize `reference_time` and `report_time` columns, automatically mapping them to `time_value` and `version`/`as_of` to match column rename [here](https://github.com/cmu-delphi/cast-api/pull/62). 

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #713, #717
